### PR TITLE
remove diamond char

### DIFF
--- a/windows-driver-docs-pr/devtest/28650-generic-value-is-not-treated-as-failure.md
+++ b/windows-driver-docs-pr/devtest/28650-generic-value-is-not-treated-as-failure.md
@@ -18,11 +18,11 @@ Returning a status value such as !TRUE is not the same as returning a status val
 
 Certain data types such as **NTSTATUS** and **HRESULT** have associated macros that classify values of these types into SUCCESS or FAILURE. These macros check the most significant bit of the returned value or values to determine this. Thus, 0 and 1 are both classified as SUCCESS values.
 
-The proper way to fix this warning is to return a proper error code instead of a generic value such as –1.
+The proper way to fix this warning is to return a proper error code instead of a generic value such as 1.
 
- 
+Â 
 
- 
+Â 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20C28650%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/30034-passing-flag-value-to-allocating-function.md
+++ b/windows-driver-docs-pr/devtest/30034-passing-flag-value-to-allocating-function.md
@@ -45,9 +45,9 @@ ExInitializeNPagedLookasideList(   pLookaside,
                 depth);
 ```
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20C30034%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/boot-options-in-efi-nvram.md
+++ b/windows-driver-docs-pr/devtest/boot-options-in-efi-nvram.md
@@ -41,9 +41,9 @@ This section includes:
 
 [Backing up Boot Options in EFI](backing-up-boot-options-in-efi.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Boot%20Options%20in%20EFI%20NVRAM%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/boot-options-in-windows-vista-and-later.md
+++ b/windows-driver-docs-pr/devtest/boot-options-in-windows-vista-and-later.md
@@ -27,11 +27,11 @@ ms.technology: windows-devices
 # Overview of Boot Options in Windows Vista and Later
 
 
-Windows Vista introduced a new boot loader architecture, a new firmware-independent boot configuration and storage system called *Boot Configuration Data* (BCD), and a new boot option editing tool, BCDEdit (BCDEdit.exe). During development, you can use BCDEdit to configure boot options for debugging, testing, and troubleshooting your driver on computers running Windows 10, Windows 8, Windows Server 2012, Windows 7, and Windows Server 2008.
+Windows Vista introduced a new boot loader architecture, a new firmware-independent boot configuration and storage system called *Boot Configuration Data* (BCD), and a new boot option editing tool, BCDEdit (BCDEdit.exe). During development, you can use BCDEdit to configure boot options for debugging, testing, and troubleshooting your driver on computers running Windows 10, Windows 8, Windows Server 2012, Windows 7, and Windows Server 2008.
 
-**Important**  Administrative privileges are required to use BCDEdit to modify BCD. Changing some boot entry options using BCDEdit could render your computer inoperable. As an alternative, use the System Configuration utility (MSConfig.exe) to change boot settings.
+**Important**  Administrative privileges are required to use BCDEdit to modify BCD. Changing some boot entry options using BCDEdit could render your computer inoperable. As an alternative, use the System Configuration utility (MSConfig.exe) to change boot settings.
 
- 
+ 
 
 ### <span id="boot_loading_architecture_in_windows_vista_and_later"></span><span id="BOOT_LOADING_ARCHITECTURE_IN_WINDOWS_VISTA_AND_LATER"></span>Boot Loading Architecture
 
@@ -55,7 +55,7 @@ Windows boot options are stored in the Boot Configuration Data (BCD) store on BI
 
 BCD replaces the traditional Boot.ini text file in BIOS-based systems. Storing boot parameters in a text file, however simple, was considered to be too vulnerable to malicious attacks to justify its use. On EFI-based computers, where boot options are stored in NVRAM, you use the same BCD methods to edit boot options as you would use on a BIOS-based computer, instead of accessing NVRAM directly using Windows APIs or specialized tools.
 
-BCD provides a common, firmware-independent boot option interface for all computers running Windows 10, Windows 8, Windows Server 2012, Windows 7, and Windows Server 2008. It is more secure than previous boot option storage configurations, because it permits secure lockdown of the BCD store and lets Administrators assign rights for managing boot options. BCD is available at run time and during all phases of setup. You can even call BCD during power state transitions and use it to define the boot process for resuming after hibernation.
+BCD provides a common, firmware-independent boot option interface for all computers running Windows 10, Windows 8, Windows Server 2012, Windows 7, and Windows Server 2008. It is more secure than previous boot option storage configurations, because it permits secure lockdown of the BCD store and lets Administrators assign rights for managing boot options. BCD is available at run time and during all phases of setup. You can even call BCD during power state transitions and use it to define the boot process for resuming after hibernation.
 
 You can manage BCD remotely and manage BCD when the system boots from media other than the media on which the BCD store resides. This feature is extremely important for debugging and troubleshooting, especially when a BCD store must be restored while running Startup Repair from a CD, from USB-based storage media, or even remotely.
 
@@ -98,9 +98,9 @@ To change boot options programmatically in Windows, use the Windows Management I
 
 [Boot Configuration Data](http://go.microsoft.com/fwlink/p/?linkid=74322)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Overview%20of%20Boot%20Options%20in%20Windows%20Vista%20and%20Later%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/code-analysis-for-drivers.md
+++ b/windows-driver-docs-pr/devtest/code-analysis-for-drivers.md
@@ -14,9 +14,9 @@ ms.technology: windows-devices
 
 Code Analysis for Drivers is a compile-time static verification tool that detects basic coding errors in C and C++ programs and includes a specialized module that is designed to detect errors in (primarily) kernel-mode driver code.
 
-**Note**  In previous versions of the WDK, the driver-specific module for code analysis was part of a stand-alone tool called PREfast for Drivers (PFD). PREfast for Drivers was also integrated into the WDK Build environment, as part of Microsoft Automated Code Review (OACR). Starting with Windows Driver Kit (WDK) 8, the driver-specific features have been integrated with the [Code Analysis tool in Visual Studio](http://go.microsoft.com/fwlink/p/?linkid=226836).
+**Note**  In previous versions of the WDK, the driver-specific module for code analysis was part of a stand-alone tool called PREfast for Drivers (PFD). PREfast for Drivers was also integrated into the WDK Build environment, as part of Microsoft Automated Code Review (OACR). Starting with Windows Driver Kit (WDK) 8, the driver-specific features have been integrated with the [Code Analysis tool in Visual Studio](http://go.microsoft.com/fwlink/p/?linkid=226836).
 
- 
+ 
 
 ## <span id="in_this_section"></span>In this section
 
@@ -26,9 +26,9 @@ Code Analysis for Drivers is a compile-time static verification tool that detect
 -   [SAL 2 Annotations for Windows Drivers](sal-2-annotations-for-windows-drivers.md)
 -   [Code Analysis for Drivers Warnings](prefast-for-drivers-warnings.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Code%20Analysis%20for%20Drivers%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/devcon.md
+++ b/windows-driver-docs-pr/devtest/devcon.md
@@ -45,21 +45,21 @@ DevCon runs on Microsoft Windows 2000 and later versions of Windows.
 <tbody>
 <tr class="odd">
 <td align="left"><p>DevCon (Devcon.exe) is included when you install the WDK, Visual Studio, and the Windows SDK for desktop apps. For information about downloading the kits, see [Windows Hardware Downloads](http://go.microsoft.com/fwlink/p/?linkid=290798).</p>
-<p><strong>Windows Driver Kit (WDK) 8 and Windows Driver Kit (WDK) 8.1</strong> (installation path)</p>
+<p><strong>Windows Driver Kit (WDK) 8 and Windows Driver Kit (WDK) 8.1</strong> (installation path)</p>
 <p>%WindowsSdkDir%\tools\x64\devcon.exe</p>
 <p>%WindowsSdkDir%\tools\x86\devcon.exe</p>
 <p>%WindowsSdkDir%\tools\arm\devcon.exe</p>
 <div class="alert">
-<strong>Note</strong>  The Visual Studio environment variable, %WindowsSdkDir%, represents the path to the Windows kits directory where the kits are installed, for example, C:\Program Files (x86)\Windows Kits\8.1.
+<strong>Note</strong>  The Visual Studio environment variable, %WindowsSdkDir%, represents the path to the Windows kits directory where the kits are installed, for example, C:\Program Files (x86)\Windows Kits\8.1.
 </div>
 <div>
- 
+ 
 </div></td>
 </tr>
 </tbody>
 </table>
 
- 
+ 
 
 This section includes:
 
@@ -74,9 +74,9 @@ Windows driver developers and testers can use DevCon to verify that a driver is 
 
 DevCon is a command-line tool that performs device management functions on local computers and remote computers.
 
-**Note**   To run DevCon commands on a remote computer, the Group Policy setting must allow the Plug and Play service to run on the remote computer. On computers that run Windows Vista and Windows 7, the Group Policy disables remote access to the service by default. On computers that run WDK 8.1 and WDK 8, the remote access is unavailable.
+**Note**  To run DevCon commands on a remote computer, the Group Policy setting must allow the Plug and Play service to run on the remote computer. On computers that run Windows Vista and Windows 7, the Group Policy disables remote access to the service by default. On computers that run WDK 8.1 and WDK 8, the remote access is unavailable.
 
- 
+ 
 
 Devcon features include:
 
@@ -116,9 +116,9 @@ The DevCon source code is also available so that you can examine the methods tha
 
 [DevCon Examples](devcon-examples.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Windows%20Device%20Console%20%28Devcon.exe%29%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/device-fundamentals-tests.md
+++ b/windows-driver-docs-pr/devtest/device-fundamentals-tests.md
@@ -66,11 +66,11 @@ ms.technology: windows-devices
 </tbody>
 </table>
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Device%20Fundamentals%20Tests%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/device-metadata-authoring-wizard-portal.md
+++ b/windows-driver-docs-pr/devtest/device-metadata-authoring-wizard-portal.md
@@ -17,7 +17,7 @@ ms.technology: windows-devices
 # Device Metadata Authoring Wizard
 
 
-\[This topic describes the Device Metadata Authoring tool provided in the Windows Driver Kit (WDK) 8. If you’re developing device experiences for Windows 8.1, use the Device Metadata Authoring Wizard available with [Microsoft Visual Studio 2013 and Windows Driver Kit (WDK) 8.1](http://go.microsoft.com/fwlink/p/?LinkId=226411). For more information, see [Windows 8.1 device experience](http://go.microsoft.com/fwlink/p/?linkid=325561). \]
+\[This topic describes the Device Metadata Authoring tool provided in the Windows Driver Kit (WDK) 8. If you're developing device experiences for Windows 8.1, use the Device Metadata Authoring Wizard available with [Microsoft Visual Studio 2013 and Windows Driver Kit (WDK) 8.1](http://go.microsoft.com/fwlink/p/?LinkId=226411). For more information, see [Windows 8.1 device experience](http://go.microsoft.com/fwlink/p/?linkid=325561). \]
 
 ## <span id="purpose"></span>Purpose
 
@@ -43,9 +43,9 @@ After using the tool to define these elements for your device or service, you ca
 
 The Device Metadata Authoring Wizard is designed for use by Independent Hardware Vendors (IHVs), Original Equipment Manufacturers (OEMs), and mobile broadband carriers.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\dma]:%20Device%20Metadata%20Authoring%20Wizard%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/enabling-wpp-tracing-through-windows-event-log.md
+++ b/windows-driver-docs-pr/devtest/enabling-wpp-tracing-through-windows-event-log.md
@@ -62,9 +62,9 @@ Declaring a channel in this manner enables both the WPP provider (whose control 
 
 WPP events are not decoded. To get message strings associated with these events, place the TMF files in the %windir%\\System32\\winevt\\TraceFormat directory. You can get the TMF files by using a utility such as Tracepdb.exe, which takes the PDB file for input and returns TMF files.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20How%20Do%20I%20Enable%20WPP%20Tracing%20Through%20the%20Windows%20Event%20Log%20Service?%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/pool-tracking.md
+++ b/windows-driver-docs-pr/devtest/pool-tracking.md
@@ -96,9 +96,9 @@ You can activate the Pool Tracking feature for one or more drivers by using Driv
 
     The Pool Tracking feature is also included in the standard settings. To use this feature, in Driver Verifier Manager, click **Create Standard Settings**.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20Pool%20Tracking%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/umdf-settings-test-use-only-tab.md
+++ b/windows-driver-docs-pr/devtest/umdf-settings-test-use-only-tab.md
@@ -22,14 +22,14 @@ By default, the [UMDF In-Flight Recorder (IFR)](https://msdn.microsoft.com/libra
 
 Also, sometimes analysis tools such as Driver Verifier can decrease system performance enough in CPU-intensive tests that the default UMDF timeout triggers even though the driver did nothing wrong. In this case, increasing the timeout value may reduce this type of accidental timeout.
 
-**Warning**  
+**Warning**  
 Using these options actually reduces the likelihood of catching or diagnosing a UMDF driver failure, so you should use them only when needed. They are more likely to be of use for testing an overall system.
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20UMDF%20Settings%20%28Test%20Use%20Only%29%20Tab%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/devtest/wdf-verifier-control-application.md
+++ b/windows-driver-docs-pr/devtest/wdf-verifier-control-application.md
@@ -23,11 +23,11 @@ ms.technology: windows-devices
 
 The Windows Driver Frameworks (WDF) Verifier control application (WdfVerifier.exe) is a tool for debugging Kernel-Mode Driver Framework (KMDF) and User-Mode Driver Framework (UMDF) drivers. You can use the tool for a quick assessment of drivers on a machine, and to make changes to their debugger settings.
 
-This documentation describes options found in the version of the application that ships as part of Windows Driver Kit (WDK) 8.1.
+This documentation describes options found in the version of the application that ships as part of Windows Driver Kit (WDK) 8.1.
 
-**Important**   To use WDF Verifier, you must have administrative privileges on the computer.
+**Important**  To use WDF Verifier, you must have administrative privileges on the computer.
 
- 
+ 
 
 ### <span id="wdf_verifier_features"></span><span id="WDF_VERIFIER_FEATURES"></span>What can I do with it?
 
@@ -70,16 +70,16 @@ This documentation describes options found in the version of the application tha
 </tr>
 <tr class="odd">
 <td align="left"><p>[My Preferences Tab](my-preferences-tab.md)</p></td>
-<td align="left"><p>This topic describes WDF Verifier's <strong>My Preferences</strong> page. On this page, you can set preferences for some of the control panel’s features.</p></td>
+<td align="left"><p>This topic describes WDF Verifier's <strong>My Preferences</strong> page. On this page, you can set preferences for some of the control panel's features.</p></td>
 </tr>
 </tbody>
 </table>
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[devtest\devtest]:%20WDF%20Verifier%20Control%20Application%20%20RELEASE:%20%2811/17/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/-sourcedisknames--section-directives.md
+++ b/windows-driver-docs-pr/display/-sourcedisknames--section-directives.md
@@ -1,6 +1,6 @@
 ---
 title: '\ SourceDiskNames\ section directives'
-description: On Windows Vista and later, in-box INFs use the \ SourceDisksXxx\ directives. 
+description: On Windows Vista and later, in-box INFs use the \ SourceDisksXxx\ directives. 
 ms.assetid: 0AC01548-3E53-41ED-9C7E-E33FC2DD14FD
 ms.author: windowsdriverdev
 ms.date: 04/20/2017
@@ -12,7 +12,7 @@ ms.technology: windows-devices
 # \[SourceDiskNames\] section directives
 
 
-On Windows Vista and later, in-box INFs use the *\[SourceDisksXxx\]* directives. However, the values of these sections were changed from what had previously typically been noted in an independent hardware vendor (IHV) production driver package.
+On Windows Vista and later, in-box INFs use the *\[SourceDisksXxx\]* directives. However, the values of these sections were changed from what had previously typically been noted in an independent hardware vendor (IHV) production driver package.
 
 ## <span id="_SourceDisksNames__and__SourceDisksFiles__section_directives"></span><span id="_sourcedisksnames__and__sourcedisksfiles__section_directives"></span><span id="_SOURCEDISKSNAMES__AND__SOURCEDISKSFILES__SECTION_DIRECTIVES"></span>*\[SourceDisksNames\]* and *\[SourceDisksFiles\]* section directives
 
@@ -44,7 +44,7 @@ IHVVID.dll      = 3426
 ## <span id="_SignatureAttributes__section_directives"></span><span id="_signatureattributes__section_directives"></span><span id="_SIGNATUREATTRIBUTES__SECTION_DIRECTIVES"></span>*\[SignatureAttributes\]* section directives
 
 
-On Windows Vista and later, inbox INFs use the *\[SignatureAttributes\]* directives.
+On Windows Vista and later, inbox INFs use the *\[SignatureAttributes\]* directives.
 
 There is no need to reference the miniport (.sys) file.
 
@@ -59,9 +59,9 @@ IHVUMD2.dll=SignatureAttributes.PETrust
 PETrust=true
 ```
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20[SourceDiskNames]%20section%20directives%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/-string--section-changes-for-localized-strings.md
+++ b/windows-driver-docs-pr/display/-string--section-changes-for-localized-strings.md
@@ -41,9 +41,9 @@ REG_MULTI_SZ   = 0x00010000
 REG_DWORD      = 0x00010001
 ```
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20[String]%20section%20changes%20for%20localized%20strings%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/access-to-non-resident-allocation.md
+++ b/windows-driver-docs-pr/display/access-to-non-resident-allocation.md
@@ -19,9 +19,9 @@ There are two distinct models of handling such invalid access dependent on wheth
 -   For engines which donâ€™t support GPU virtual addressing and use the allocation and patch location list to patch memory references, an invalid access occurs when the user mode driver submits an allocation list which references an allocation which is not resident on the device (i.e. the user mode driver hasnâ€™t called [*MakeResidentCb*](https://msdn.microsoft.com/library/windows/hardware/dn906357) on that allocation). When this occurs, the graphics kernel will put the faulty context/device in error.
 -   For engines which do support GPU virtual addressing but access a GPU virtual address that is invalid, either because there is no allocation behind the virtual address or there is a valid allocation but it hasnâ€™t been made resident, the GPU is expected to raise an unrecoverable page fault in the form of an interrupt. When the page fault interrupt occurs, the kernel mode driver will need to forward the error to the graphics kernel through a new page fault notification. Upon receiving this notification, the graphics kernel will initiate an engine reset on the faulting engine and put the faulty context/device in error. If the engine reset is unsuccessful, the graphics kernel will promote the error to a full adapter wide timeout detection and recovery (TDR).
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Access%20to%20non-resident%20allocation%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/calling-displayconfig-functions-for-a-miracast-target.md
+++ b/windows-driver-docs-pr/display/calling-displayconfig-functions-for-a-miracast-target.md
@@ -20,9 +20,9 @@ To reduce compatibility issues of existing apps being exposed to new Miracast ta
 -   The [**DISPLAYCONFIG\_VIDEO\_SIGNAL\_INFO**](https://msdn.microsoft.com/library/windows/hardware/ff554007) structure has a VSync frequency divider member, **vSyncFreqDivider**, thatâ€™s used similarly to [**D3DKMDT\_VIDEO\_SIGNAL\_INFO**](https://msdn.microsoft.com/library/windows/hardware/ff546625).**vSyncFreqDivider**.
 -   The [**DisplayConfigGetDeviceInfo**](https://msdn.microsoft.com/library/windows/hardware/ff553903) function provides the base connector type for any target. In the case of a Miracast target, this function always returns a value of **DISPLAYCONFIG\_OUTPUT\_TECHNOLOGY\_MIRACAST** in the [**DISPLAYCONFIG\_VIDEO\_OUTPUT\_TECHNOLOGY**](https://msdn.microsoft.com/library/windows/hardware/ff554003) enumeration.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Calling%20DisplayConfig%20functions%20for%20a%20Miracast%20target%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/general-install-section-directives.md
+++ b/windows-driver-docs-pr/display/general-install-section-directives.md
@@ -16,9 +16,9 @@ This is a general reminder that all references to out-of-box or production/retai
 
 Do not refer to anything that is required by your OpenGL ICDs, OpenCL, Control Panel, Help files, out-of-box services, polling applications, and so on.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20General%20install%20section%20directives%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/gpu-power-management-of-idle-and-active-power.md
+++ b/windows-driver-docs-pr/display/gpu-power-management-of-idle-and-active-power.md
@@ -12,7 +12,7 @@ ms.technology: windows-devices
 # GPU power management of idle states and active power
 
 
-Starting with Windows 8, an optional GPU power management infrastructure is available that lets Windows Display Driver Model (WDDM) 1.2 and later drivers manage power for individual devices or a set of devices. This infrastructure provides a standardized mechanism to support F-state and P-state power management in collaboration with Windows.
+Starting with Windows 8, an optional GPU power management infrastructure is available that lets Windows Display Driver Model (WDDM) 1.2 and later drivers manage power for individual devices or a set of devices. This infrastructure provides a standardized mechanism to support F-state and P-state power management in collaboration with Windows.
 
 |                                                                                   |                                        |
 |-----------------------------------------------------------------------------------|----------------------------------------|
@@ -21,12 +21,12 @@ Starting with Windows 8, an optional GPU power management infrastructure is avai
 | Driver implementation                                                             | Optional                               |
 | [WHCK]( http://go.microsoft.com/fwlink/p/?linkid=258342) requirements and tests | **Device.Graphicsâ€¦RuntimePowerMgmt** |
 
- 
+ 
 
 ## <span id="GPU_power_management_device_driver_interface__DDI_"></span><span id="gpu_power_management_device_driver_interface__ddi_"></span><span id="GPU_POWER_MANAGEMENT_DEVICE_DRIVER_INTERFACE__DDI_"></span>GPU power management device driver interface (DDI)
 
 
-These new and updated functions and structures are available starting with Windows 8 for the display miniport driver to transition the state of power components and to communicate power events with the Microsoft DirectX graphics kernel subsystem.
+These new and updated functions and structures are available starting with Windows 8 for the display miniport driver to transition the state of power components and to communicate power events with the Microsoft DirectX graphics kernel subsystem.
 
 -   [*DxgkCbCompleteFStateTransition*](https://msdn.microsoft.com/library/windows/hardware/jj128349)
 -   [*DxgkCbPowerRuntimeControlRequest*](https://msdn.microsoft.com/library/windows/hardware/hh451323)
@@ -53,18 +53,18 @@ GPUs and display screens are two of the largest power consumers in laptops, mobi
 These are the key power management scenarios to reduce power consumption and extend battery life:
 
 -   Mobile form factor devices can go into an idle state and save power because individual system components shut down if they are not in use.
--   Windows System on a Chip (SoC)â€“based devices behave like consumer devices and mobile phones—that is, they turn on immediately when they are needed, thereby saving energy.
+-   Windows System on a Chip (SoC)â€“based devices behave like consumer devices and mobile phones that is, they turn on immediately when they are needed, thereby saving energy.
 
 ## <span id="Hardware_certification_requirements"></span><span id="hardware_certification_requirements"></span><span id="HARDWARE_CERTIFICATION_REQUIREMENTS"></span>Hardware certification requirements
 
 
 For info on requirements that hardware devices must meet when they implement this feature, refer to the relevant [WHCK documentation]( http://go.microsoft.com/fwlink/p/?linkid=258342) on **Device.Graphicsâ€¦RuntimePowerMgmt**.
 
-See [WDDM 1.2 features](wddm-v1-2-features.md) for a review of features added with Windows 8.
+See [WDDM 1.2 features](wddm-v1-2-features.md) for a review of features added with Windows 8.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20GPU%20power%20management%20of%20idle%20states%20and%20active%20power%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/gpu-virtual-memory-in-wddm-2-0.md
+++ b/windows-driver-docs-pr/display/gpu-virtual-memory-in-wddm-2-0.md
@@ -12,7 +12,7 @@ ms.technology: windows-devices
 # GPU virtual memory in WDDM 2.0
 
 
-This section provides details about GPU virtual memory, including why the changes were made and how drivers will use it. This functionality is available starting with Windows 10.
+This section provides details about GPU virtual memory, including why the changes were made and how drivers will use it. This functionality is available starting with Windows 10.
 
 ## <span id="Introduction"></span><span id="introduction"></span><span id="INTRODUCTION"></span>Introduction
 
@@ -42,9 +42,9 @@ In the *IoMmu* model, the CPU and GPU share a common address space and page tabl
 
 For more information, see [IoMmu model](iommu-model.md).
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20GPU%20virtual%20memory%20in%20WDDM%202.0%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/performing-copp-operations-example.md
+++ b/windows-driver-docs-pr/display/performing-copp-operations-example.md
@@ -143,9 +143,9 @@ DWORD APIENTRY
 }
 ```
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Performing%20COPP%20Operations%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/plug-and-play--pnp--start-and-stop-cases.md
+++ b/windows-driver-docs-pr/display/plug-and-play--pnp--start-and-stop-cases.md
@@ -31,7 +31,7 @@ All Windows Display Driver Model (WDDM) 1.2 and later display miniport drivers m
 <td align="left">8</td>
 </tr>
 <tr class="odd">
-<td align="left">Driver implementation—Full graphics and Display only</td>
+<td align="left">Driver implementation Full graphics and Display only</td>
 <td align="left">Mandatory</td>
 </tr>
 <tr class="even">
@@ -41,12 +41,12 @@ All Windows Display Driver Model (WDDM) 1.2 and later display miniport drivers m
 </tbody>
 </table>
 
- 
+ 
 
 ## <span id="Display_miniport_driver_PnP_DDI"></span><span id="display_miniport_driver_pnp_ddi"></span><span id="DISPLAY_MINIPORT_DRIVER_PNP_DDI"></span>Display miniport driver PnP DDI
 
 
-Starting in Windows 8, the Microsoft DirectX graphics kernel subsystem provides this function that a driver can call if the display device is started or resumed from hibernation:
+Starting in Windows 8, the Microsoft DirectX graphics kernel subsystem provides this function that a driver can call if the display device is started or resumed from hibernation:
 
 -   [**DxgkCbAcquirePostDisplayOwnership**](https://msdn.microsoft.com/library/windows/hardware/hh451339)
 
@@ -82,7 +82,7 @@ These are the return codes that the driver should return after a PnP start proce
 <tbody>
 <tr class="odd">
 <td align="left"><p><span id="Success"></span><span id="success"></span><span id="SUCCESS"></span>Success</p></td>
-<td align="left"><p>Behavior is the same as in Windows 7.</p>
+<td align="left"><p>Behavior is the same as in Windows 7.</p>
 <p>For a BIOS-based system, if the driver starts successfully, the frame buffer is still active and the driver must be ready to set to a valid mode.</p></td>
 </tr>
 <tr class="even">
@@ -93,7 +93,7 @@ These are the return codes that the driver should return after a PnP start proce
 </tbody>
 </table>
 
- 
+ 
 
 ## <span id="PnP_stop_operation"></span><span id="pnp_stop_operation"></span><span id="PNP_STOP_OPERATION"></span>PnP stop operation
 
@@ -130,14 +130,14 @@ These are the return codes that the driver should return after a PnP stop proces
 </tr>
 <tr class="odd">
 <td align="left"><p><span id="Failure"></span><span id="failure"></span><span id="FAILURE"></span>Failure</p></td>
-<td align="left"><p>The operating system calls the Windows 7-style PnP stop driver interface through the [<em>DxgkDdiStopDevice</em>](https://msdn.microsoft.com/library/windows/hardware/ff560781) function.</p>
+<td align="left"><p>The operating system calls the Windows 7-style PnP stop driver interface through the [<em>DxgkDdiStopDevice</em>](https://msdn.microsoft.com/library/windows/hardware/ff560781) function.</p>
 <p>For a BIOS-based system, the driver must set the display into a BIOS-compatible mode.</p>
 <p>For a UEFI-based system, the basic display driver runs in headless mode on the graphics adapter.</p></td>
 </tr>
 </tbody>
 </table>
 
- 
+ 
 
 For further requirements on PnP and other state transitions, see [Providing seamless state transitions in WDDM 1.2 and later](seamless-state-transitions-in-wddm-1-2-and-later.md).
 
@@ -146,11 +146,11 @@ For further requirements on PnP and other state transitions, see [Providing seam
 
 For info on requirements that hardware devices must meet when they implement this feature, refer to the relevant [WHCK documentation]( http://go.microsoft.com/fwlink/p/?linkid=258342) on **Device.Graphics.WDDM12.Display.PnpStopStartSupport**.
 
-See [WDDM 1.2 features](wddm-v1-2-features.md) for a review of features added with Windows 8.
+See [WDDM 1.2 features](wddm-v1-2-features.md) for a review of features added with Windows 8.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Plug%20and%20Play%20%28PnP%29%20in%20WDDM%201.2%20and%20later%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/required-direct3d-9-capabilities.md
+++ b/windows-driver-docs-pr/display/required-direct3d-9-capabilities.md
@@ -168,13 +168,13 @@ For applications to fully access the features of Microsoft Direct3D versions 9\_
 </tbody>
 </table>
 
- 
+ 
 
-**Note**  These requirements also apply:
+**Note**  These requirements also apply:
 -   The driver must also set the **TextureCaps** member to a value of D3DPTEXTURECAPS\_NONPOW2CONDITIONAL and D3DPTEXTURECAPS\_POW2, or to neither.
 -   When the driver responds to an event, where [**D3DDDIARG\_CREATEQUERY**](https://msdn.microsoft.com/library/windows/hardware/ff542958).**QueryType** is D3DDDIQUERYTYPE\_EVENT, it must always set the event's **BOOL** value to **TRUE** when responding. See [*CreateQuery*](https://msdn.microsoft.com/library/windows/hardware/ff540673) and **D3DDDIARG\_CREATEQUERY**.
 
- 
+ 
 
 ## <span id="Minimum_capabilities_for_Direct3D_level_9_2"></span><span id="minimum_capabilities_for_direct3d_level_9_2"></span><span id="MINIMUM_CAPABILITIES_FOR_DIRECT3D_LEVEL_9_2"></span>Minimum capabilities for Direct3D level 9\_2
 
@@ -244,12 +244,12 @@ These capabilities must be set in addition to those listed for Direct3D level 9\
 </tbody>
 </table>
 
- 
+ 
 
-**Note**  This requirement also applies:
+**Note**  This requirement also applies:
 -   When the driver responds to a *z*-testing query, where [**D3DDDIARG\_CREATEQUERY**](https://msdn.microsoft.com/library/windows/hardware/ff542958).**QueryType** is D3DDDIQUERYTYPE\_OCCLUSION, it must always set the query's **UINT** value to a non-zero value when responding. See [*CreateQuery*](https://msdn.microsoft.com/library/windows/hardware/ff540673) and **D3DDDIARG\_CREATEQUERY**.
 
- 
+ 
 
 ## <span id="Minimum_capabilities_for_Direct3D_level_9_3"></span><span id="minimum_capabilities_for_direct3d_level_9_3"></span><span id="MINIMUM_CAPABILITIES_FOR_DIRECT3D_LEVEL_9_3"></span>Minimum capabilities for Direct3D level 9\_3
 
@@ -320,15 +320,15 @@ These capabilities must be set in addition to those listed for Direct3D levels 9
 </tbody>
 </table>
 
- 
+ 
 
-**Note**  The **VertexShaderVersion** value of D3DVS\_VERSION(3,0) guarantees instancing support. Direct3D 10Level 9 does not expose Shader Model 3.0.
+**Note**  The **VertexShaderVersion** value of D3DVS\_VERSION(3,0) guarantees instancing support. Direct3D 10Level 9 does not expose Shader Model 3.0.
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Required%20Direct3D%209%20capabilities%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/support-for-headless-systems.md
+++ b/windows-driver-docs-pr/display/support-for-headless-systems.md
@@ -18,9 +18,9 @@ Because the stub display is used when no PnP driver is available, no third-party
 
 On architectures in which VGA has been the norm, MSBDD requires positive confirmation that VGA is not present; otherwise, it assumes that VGA hardware is available and that the system is not headless. System firmware should set the VGA Not Present flag in the IAPC\_BOOT\_ARCH field of FADT and if there is any VBIOS, it should implement an empty mode list through the VESA BIOS Extensions (VBE). These mechanisms should indicate that VGA is not present even if the system implements a VBIOS with int 10h mode 12h support for compatibility with previous versions of Windows. In the absence of VBE support, the Basic Display Driver uses a display that is initialized by the boot loader, so a headless system should not represent a working display through UEFI GOP.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Support%20for%20headless%20systems%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/supporting-display-output.md
+++ b/windows-driver-docs-pr/display/supporting-display-output.md
@@ -27,17 +27,17 @@ The display miniport driver or ACPI methods that are exposed by the system BIOS 
 
 The following aliases for the ACPI display output are defined in Dispmprt.h:
 
--   ACPI\_METHOD\_DISPLAY\_DOD - Enumerates all the devices attached to the display adapter. This method is required if the integrated controller supports switching of output devices. This is the alias name for the DOD\_ method defined by the ACPI specification.
--   ACPI\_METHOD\_DISPLAY\_DOS - Indicates that the system firmware is capable of automatically switching the active display output. This is the alias name for the SOD\_ method defined by the ACPI specification. The following are the allowed parameters:
+-   ACPI\_METHOD\_DISPLAY\_DOD - Enumerates all the devices attached to the display adapter. This method is required if the integrated controller supports switching of output devices. This is the alias name for the DOD\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_DISPLAY\_DOS - Indicates that the system firmware is capable of automatically switching the active display output. This is the alias name for the SOD\_ method defined by the ACPI specification. The following are the allowed parameters:
     -   ACPI\_ARG\_ENABLE\_SWITCH\_EVENT. States that the system firmware should not automatically switch the active display output device. Instead, it must save the desired change in state variables associated with each display output device and generate a display switch event. The operating system can query the active status of a device by calling the ACPI\_METHOD\_OUTPUT\_DGS method.
     -   ACPI\_ARG\_ENABLE\_AUTO\_SWITCH. States that the system firmware should automatically switch the active display output device without interacting with the operating system. It does not generate a display switch event.
     -   ACPI\_ARG\_DISABLE\_SWITCH\_EVENT. States that the system firmware should not perform any action; that is, neither switch the output device nor notify the operating system. The values returned by the ACPI\_METHOD\_OUTPUT\_DGS method are locked.
--   ACPI\_METHOD\_OUTPUT\_DCS - Returns the status of a display output device. This is the alias name for the CSD\_ method defined by the ACPI specification.
--   ACPI\_METHOD\_OUTPUT\_DGS - Checks whether the status of a display output device is active. This is the alias name for the SGD\_ method defined by the ACPI specification.
--   ACPI\_METHOD\_OUTPUT\_DSS - Sets the status of a display output device to active or inactive. This is the alias name for the SSD\_ method defined by the ACPI specification. The operating system manages this action to avoid flickering.
--   ACPI\_METHOD\_DISPLAY\_GPD - Queries the CMOS entry to determine which video device is posted at boot time. This is the alias name for the DPG\_ method defined by the ACPI specification.
--   ACPI\_METHOD\_DISPLAY\_SPD - Updates the CMOS entry that determines which video device is posted at boot time. This is the alias name for the DPS\_ method defined by the ACPI specification.
--   ACPI\_METHOD\_DISPLAY\_VPO - Determines what video options are implemented. This is the alias name for the OPV\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_OUTPUT\_DCS - Returns the status of a display output device. This is the alias name for the CSD\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_OUTPUT\_DGS - Checks whether the status of a display output device is active. This is the alias name for the SGD\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_OUTPUT\_DSS - Sets the status of a display output device to active or inactive. This is the alias name for the SSD\_ method defined by the ACPI specification. The operating system manages this action to avoid flickering.
+-   ACPI\_METHOD\_DISPLAY\_GPD - Queries the CMOS entry to determine which video device is posted at boot time. This is the alias name for the DPG\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_DISPLAY\_SPD - Updates the CMOS entry that determines which video device is posted at boot time. This is the alias name for the DPS\_ method defined by the ACPI specification.
+-   ACPI\_METHOD\_DISPLAY\_VPO - Determines what video options are implemented. This is the alias name for the OPV\_ method defined by the ACPI specification.
 
 ## <span id="External_Asynchronous_Events"></span><span id="external_asynchronous_events"></span><span id="EXTERNAL_ASYNCHRONOUS_EVENTS"></span>External Asynchronous Events
 
@@ -48,27 +48,27 @@ The operating system must be notified about external, asynchronous events that a
 -   ACPI\_NOTIFY\_NEXT\_DISPLAY\_HOTKEY - Notifies the operating system that the user has pressed the next display keyboard shortcut.
 -   ACPI\_NOTIFY\_PREV\_DISPLAY\_HOTKEY - Notifies the operating system that the user has pressed the previous display keyboard shortcut.
 
-**Note**  The previous notifications depend on the handling of the event caused by the user when pressing the keyboard shortcuts.
+**Note**  The previous notifications depend on the handling of the event caused by the user when pressing the keyboard shortcuts.
 
- 
+ 
 
 The following are the types of requests that the display miniport driver can make to the operating system.
 
 -   DXGK\_ACPI\_CHANGE\_DISPLAY\_MODE - Requests to initiate a mode change to the new recommended active video present network (VidPN).
 -   DXGK\_ACPI\_POLL\_DISPLAY\_CHILDREN - Requests to poll the connectivity of the children of the display adapter.
 
-**Note**  The previous requests are the values of the *AcpiFlags* parameter returned by the [**DxgkDdiNotifyAcpiEvent**](https://msdn.microsoft.com/library/windows/hardware/ff559695) function.
+**Note**  The previous requests are the values of the *AcpiFlags* parameter returned by the [**DxgkDdiNotifyAcpiEvent**](https://msdn.microsoft.com/library/windows/hardware/ff559695) function.
 
- 
+ 
 
 ## <span id="related_topics"></span>Related topics
 
 
 [Supporting Brightness Controls on Integrated Display Panels](supporting-brightness-controls-on-integrated-display-panels.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Supporting%20Display%20Output%20and%20ACPI%20Events%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/using-cross-adapter-resources-in-a-hybrid-system.md
+++ b/windows-driver-docs-pr/display/using-cross-adapter-resources-in-a-hybrid-system.md
@@ -12,7 +12,7 @@ ms.technology: windows-devices
 # <span id="display.using_cross-adapter_resources_in_a_hybrid_system"></span>Using cross-adapter resources in a hybrid system
 
 
-Starting in Windows 8.1, a Windows Display Driver Model (WDDM) driver can support a *hybrid system*, where *cross-adapter resources* are shared between an integrated GPU and a discrete GPU, and an application can be run on either GPU, depending on the needs of the application. The operating system and driver together determine which GPU an application should run on.
+Starting in Windows 8.1, a Windows Display Driver Model (WDDM) driver can support a *hybrid system*, where *cross-adapter resources* are shared between an integrated GPU and a discrete GPU, and an application can be run on either GPU, depending on the needs of the application. The operating system and driver together determine which GPU an application should run on.
 
 The display miniport driver should express support for cross-adapter resources by setting the **CrossAdapterResource** member of the [**DXGK\_VIDMMCAPS**](https://msdn.microsoft.com/library/windows/hardware/ff562072) structure.
 
@@ -38,7 +38,7 @@ These subsequent topics give more details on driver implementation for hybrid sy
 ## <span id="definition_of_a_cross_adapter_resource"></span><span id="DEFINITION_OF_A_CROSS_ADAPTER_RESOURCE"></span>Definition and properties of a cross-adapter resource:
 
 
--   A cross-adapter resource is available only starting in Windows 8.1.
+-   A cross-adapter resource is available only starting in Windows 8.1.
 -   It can be paged-in only to the aperture GPU memory segment.
 -   It is allocated as a shared resource.
 -   It has only one allocation, in a linear format.
@@ -48,9 +48,9 @@ These subsequent topics give more details on driver implementation for hybrid sy
 -   It might be created as a standard allocation from kernel mode by the display miniport driver and then be opened later by the user-mode display driver.
 -   It might be created by the user-mode display driver.
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Using%20cross-adapter%20resources%20in%20a%20hybrid%20system%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/what-s-new-for-windows-8-display-drivers.md
+++ b/windows-driver-docs-pr/display/what-s-new-for-windows-8-display-drivers.md
@@ -15,7 +15,7 @@ ms.technology: windows-devices
 # What's new for Windows 8 display drivers (WDDM 1.2)
 
 
-Windows 8 introduced version 1.2 of the Windows Display Driver Model (WDDM). WDDM 1.2 also supports Microsoft Direct3D Version 11.1. See these topics for info on features, guidance to independent hardware vendors (IHVs), and hardware requirements:
+Windows 8 introduced version 1.2 of the Windows Display Driver Model (WDDM). WDDM 1.2 also supports Microsoft Direct3D Version 11.1. See these topics for info on features, guidance to independent hardware vendors (IHVs), and hardware requirements:
 
 <span id="wddm_1.2_and_windows_8"></span><span id="WDDM_1.2_AND_WINDOWS_8"></span>[WDDM 1.2 and Windows 8](wddm-in-windows-8.md)  
 Overview of WDDM 1.2
@@ -51,9 +51,9 @@ XR and XR\_BIAS format requirements have been corrected in these topics:
 
 [Conversion from BGR8888 to XR\_BIAS](conversion-from-bgr8888-to-xr-bias.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20What's%20new%20for%20Windows%208%20display%20drivers%20%28WDDM%201.2%29%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/what-s-new-for-windows-threshold-display-drivers--wddm-2-0-.md
+++ b/windows-driver-docs-pr/display/what-s-new-for-windows-threshold-display-drivers--wddm-2-0-.md
@@ -1,5 +1,5 @@
 ---
-title: What's new for Windows 10 display drivers (WDDM 2.0)
+title: What's new for Windows 10 display drivers (WDDM 2.0)
 description: Describes new features in Windows 10 for display drivers
 ms.assetid: 619175D4-98DA-4B17-8F6F-71B13A31374D
 ms.author: windowsdriverdev
@@ -9,7 +9,7 @@ ms.prod: windows-hardware
 ms.technology: windows-devices
 ---
 
-# What's new for Windows 10 display drivers (WDDM 2.0)
+# What's new for Windows 10 display drivers (WDDM 2.0)
 
 
 ### <span id="Memory_Management"></span><span id="memory_management"></span><span id="MEMORY_MANAGEMENT"></span>Memory Management
@@ -31,9 +31,9 @@ Driver residency
 -   New DDIs have been added for process synchronization and context monitoring.
 
 For more details, see [Driver residency in WDDM 2.0](driver-residency-in-wddm-2-0.md).
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20What's%20new%20for%20Windows%C2%A010%20display%20drivers%20%28WDDM%202.0%29%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/display/windows-8-in-box-graphics-drivers-treated-as-generic-drivers-.md
+++ b/windows-driver-docs-pr/display/windows-8-in-box-graphics-drivers-treated-as-generic-drivers-.md
@@ -20,14 +20,14 @@ If the default settings for Windows 8 Windows Update are being used, an Importan
 
 When Windows 8 ships, the in-box graphics drivers are significantly older than the latest driver updates on Windows Update. This behavior ensures that the user experiences Windows 8 by using the latest/best graphics driver available.
 
-**Note**  
+**Note**  
 The Windows 8 certified OEM graphics drivers that is provided on new computers sold with Windows 8 pre-installed are not considered generic. A newer, matching graphics driver on Windows Update would be offered as an Optional update in these cases. The user must actively choose to install an Optional driver update.
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[display\display]:%20Windows%208%20in-box%20graphics%20drivers%20treated%20as%20generic%20drivers%20%20%20RELEASE:%20%282/10/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/gettingstarted/concepts-and-knowledge-for-all-driver-developers.md
+++ b/windows-driver-docs-pr/gettingstarted/concepts-and-knowledge-for-all-driver-developers.md
@@ -25,9 +25,9 @@ In this section:
 -   [Header files in the Windows Driver Kit](header-files-in-the-windows-driver-kit.md)
 -   [Writing drivers for different versions of Windows](platforms-and-driver-versions.md)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[wdkgetstart\wdkgetstart]:%20Concepts%20%20for%20all%20driver%20developers%20%20RELEASE:%20%281/20/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/gettingstarted/extensions-and-driver-triples.md
+++ b/windows-driver-docs-pr/gettingstarted/extensions-and-driver-triples.md
@@ -42,9 +42,9 @@ Here are some examples of event handlers that are implemented by SpbCx.sys
 
 -   EvtIoRead
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[wdkgetstart\wdkgetstart]:%20KMDF%20extensions%20and%20driver%20triples%20%20RELEASE:%20%281/20/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/gettingstarted/kmdf-as-a-generic-pair-model.md
+++ b/windows-driver-docs-pr/gettingstarted/kmdf-as-a-generic-pair-model.md
@@ -66,9 +66,9 @@ In a (KMDF driver, Framework) pair, the Framework handles tasks that are common 
 
 [Kernel-Mode Driver Framework](https://msdn.microsoft.com/library/windows/hardware/ff557565)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[wdkgetstart\wdkgetstart]:%20KMDF%20as%20a%20generic%20driver%20pair%20model%20%20RELEASE:%20%281/20/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/gettingstarted/upper-and-lower-edges-of-drivers.md
+++ b/windows-driver-docs-pr/gettingstarted/upper-and-lower-edges-of-drivers.md
@@ -74,9 +74,9 @@ The terms *upper edge* and *lower edge* are used to describe the interfaces that
 
 [Network Drivers Starting with Windows Vista](https://msdn.microsoft.com/library/windows/hardware/ff570021)
 
- 
+ 
 
- 
+ 
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[wdkgetstart\wdkgetstart]:%20Upper%20and%20lower%20edges%20of%20drivers%20%20RELEASE:%20%281/20/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 

--- a/windows-driver-docs-pr/sensors/architecture-overview-for-sensor-drivers.md
+++ b/windows-driver-docs-pr/sensors/architecture-overview-for-sensor-drivers.md
@@ -21,13 +21,13 @@ A sensor driver uses a special **class extension** object. The sensor class exte
 
 For more information about the class extension object, see [About the Sensor Class Extension](about-the-sensor-class-extension.md).
 
-**Important**  Sensor drivers must be free threaded and thread safe.
+**Important**  Sensor drivers must be free threaded and thread safe.
 
- 
+ 
 
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/connect-to-hardware.md
+++ b/windows-driver-docs-pr/sensors/connect-to-hardware.md
@@ -118,7 +118,7 @@ WdfWaitLockAcquire(pAccDevice->m_I2CWaitLock, NULL);
    Status = I2CSensorWriteRegister(pAccDevice->m_I2CIoTarget, RegisterSetting.Register, &amp;RegisterSetting.Value, sizeof(RegisterSetting.Value));
 ```
 
-In the preceding code, the I2C connection is used to set the accelerometer to “measure mode” to make it ready for reading sensor values. See the *adxl345.h* header file for the definitions of ADXL345\_POWER\_CTL, ADXL345\_POWER\_CTL\_MEASURE and some other constants used in the sample sensor driver.
+In the preceding code, the I2C connection is used to set the accelerometer to  measure mode  to make it ready for reading sensor values. See the *adxl345.h* header file for the definitions of ADXL345\_POWER\_CTL, ADXL345\_POWER\_CTL\_MEASURE and some other constants used in the sample sensor driver.
 
 4. Find the following code:
 ```ManagedCPlusPlus
@@ -178,9 +178,9 @@ The preceding code is used to delete the wait lock on the device object.
 ```
 
 3. Close the *client.cpp* file.
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/how-to-build-a-universal-sensor-driver.md
+++ b/windows-driver-docs-pr/sensors/how-to-build-a-universal-sensor-driver.md
@@ -1,7 +1,7 @@
 ---
 title: How to build a universal sensor driver
 author: windows-driver-content
-description: A universal sensor driver is a sensor driver that is developed based on the universal sensor driver model for Windows 10. 
+description: A universal sensor driver is a sensor driver that is developed based on the universal sensor driver model for Windows 10. 
 ms.assetid: 759E01CA-9838-4CBF-B5D1-2DCD2230A48A
 ms.author: windowsdriverdev
 ms.date: 04/20/2017
@@ -13,7 +13,7 @@ ms.technology: windows-devices
 # How to build a universal sensor driver
 
 
-A *universal sensor driver* is a sensor driver that is developed based on the universal sensor driver model for Windows 10. And the topics in this section show you how to build such a sensor driver.
+A *universal sensor driver* is a sensor driver that is developed based on the universal sensor driver model for Windows 10. And the topics in this section show you how to build such a sensor driver.
 
 This universal sensor driver development exercise is based on a development board called [Sharks Cove]( http://firmware.intel.com/projects/sharks-cove-uefi-firmware).
 
@@ -25,9 +25,9 @@ The following topics provide detailed guidance for the tasks that you need to pe
 -   [Write and deploy your universal sensor driver](write-and-deploy-your-universal-sensor-driver.md)
 -   [Test your universal sensor driver](test-your-universal-sensor-driver.md)
 
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/install-the-sensor-driver.md
+++ b/windows-driver-docs-pr/sensors/install-the-sensor-driver.md
@@ -15,13 +15,13 @@ ms.technology: windows-devices
 
 This topic shows you how to install the sensor driver on a development board, after you update the secondary system description table (SSDT) for the development board.
 
-This topic uses the Sharks Cove development board and an ADXL345 accelerometer as a case study, to help explain the process of installing a sensor driver on a development board. So if you want to perform the tasks presented in this topic, you must first install an operating system on the Sharks Cove. For more information about how to do that, see [Download kits and tools for Windows 10](https://msdn.microsoft.com/windows/hardware/dn913721.aspx), and follow the instructions in **Step 1** (Install Windows 10).
+This topic uses the Sharks Cove development board and an ADXL345 accelerometer as a case study, to help explain the process of installing a sensor driver on a development board. So if you want to perform the tasks presented in this topic, you must first install an operating system on the Sharks Cove. For more information about how to do that, see [Download kits and tools for Windows 10](https://msdn.microsoft.com/windows/hardware/dn913721.aspx), and follow the instructions in **Step 1** (Install Windows 10).
 
 After you finish installing the operating system on the Sharks Cove, See [Build the sensor driver](build-the-sensor-driver.md) to learn how to build a driver in Microsoft Visual Studio. Then return here to continue.
 
 The accelerometer is attached to the Sharks Cove via the I2C bus. Peripherals that are connected to the I2C bus are enumerated via the Advanced Configuration and Power Interface (ACPI). So the sample driver for the accelerometer was developed to support ACPI instead of Plug and Play.
 
-To make the Sharks Cove’s ACPI driver aware of the new device (the accelerometer) on the I2C bus, you must add information about the accelerometer to the SSDT on the Sharks Cove. This table describes the hardware resources and interrupt requirements for a hardware platform’s devices, including attached peripherals like the accelerometer.
+To make the Sharks Cove's ACPI driver aware of the new device (the accelerometer) on the I2C bus, you must add information about the accelerometer to the SSDT on the Sharks Cove. This table describes the hardware resources and interrupt requirements for a hardware platform's devices, including attached peripherals like the accelerometer.
 
 ## Before you begin
 
@@ -177,12 +177,12 @@ Before you install the sample sensor driver, you must turn on testsigning. Perfo
 
 1. In the Command prompt window, enter the following command to see whether testsigning is already turned on.
 **bcdedit /enum**
-2. If you see a listing similar to the following, showing an entry for testsigning, with its value set to “yes” then skip to **Step 5**.
+2. If you see a listing similar to the following, showing an entry for testsigning, with its value set to  yes  then skip to **Step 5**.
 ![command prompt window showing testsigning set to yes.](images/testsigning.png)
 
 3. If you need to turn on test signing, then enter the following command:
 **bcdedit /set testsigning on**
-4. Repeat **Step 1** (in this exercise) to verify that the value of the testsigning system variable is now set to “yes” in the Windows Boot Loader list.
+4. Repeat **Step 1** (in this exercise) to verify that the value of the testsigning system variable is now set to  yes  in the Windows Boot Loader list.
 
 5. Restart the Sharks Cove. As the board restarts, hold the Volume-up button for about 2 seconds, to enter system setup (UEFI) window.
 
@@ -224,9 +224,9 @@ For information about how to use Visual Studio to deploy a driver to a client co
 
 After successfully installing the sample sensor driver, see [Test your universal sensor driver](test-your-universal-sensor-driver.md) for information about how to test a sensor.
 
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/sensors-acpi-entries.md
+++ b/windows-driver-docs-pr/sensors/sensors-acpi-entries.md
@@ -1,7 +1,7 @@
 ---
 title: Sensors ACPI entries
 author: windows-driver-content
-description: This topic describes the advanced configuration and power management interface (ACPI) entries that are specific to sensors in Windows 10.
+description: This topic describes the advanced configuration and power management interface (ACPI) entries that are specific to sensors in Windows 10.
 ms.assetid: DFDD5603-18F5-4F6C-8D09-D6905587F3CE
 ms.author: windowsdriverdev
 ms.date: 04/20/2017
@@ -13,7 +13,7 @@ ms.technology: windows-devices
 # Sensors ACPI entries
 
 
-This topic describes the advanced configuration and power management interface (ACPI) entries that are specific to sensors in Windows 10 Mobile. These entries are to be added to the ACPI source language (ASL) file.
+This topic describes the advanced configuration and power management interface (ACPI) entries that are specific to sensors in Windows 10 Mobile. These entries are to be added to the ACPI source language (ASL) file.
 
 ## ROTM
 
@@ -49,9 +49,9 @@ Method(PRIM, 0x0, NotSerialized) {
 
 **Note:** If there are multiple sensors of the same kind on the mobile device (for example, multiple accelerometers), then one of them must be marked as primary using the **PRIM** keyword. The primary sensor will be used by the WinRT API when the sensor's GetDefault method is invoked. The primary sensor will also be used by any operating system features that are dependent on that sensor type.
 
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/spbaccelerometer-driver-overview.md
+++ b/windows-driver-docs-pr/sensors/spbaccelerometer-driver-overview.md
@@ -17,9 +17,9 @@ This sample UMDF driver controls an ADXL345 accelerometer that is connected to a
 
 Even if your system doesn't support this sensor, you can use the sample driver as a reference for integrating other devices over I2C.
 
- 
+ 
 
- 
+ 
 
 
 --------------------

--- a/windows-driver-docs-pr/sensors/testing-location-functionality.md
+++ b/windows-driver-docs-pr/sensors/testing-location-functionality.md
@@ -15,9 +15,9 @@ ms.technology: windows-devices
 
 The Sensor Diagnostic Tool includes a separate Location tab that logs properties that are specific to location. These properties include Latitude, Longitude, and Civic Address.
 
-**Note**  The Sensor Diagnostic Tool is acceptable for testing on Windows 8.1 and earlier operating systems. The tool is now deprecated for Windows 10, so for sensor driver testing and diagnostics on Windows 10 and later operating systems, please use the SensorInfo App from the Windows Store.
+**Note**  The Sensor Diagnostic Tool is acceptable for testing on Windows 8.1 and earlier operating systems. The tool is now deprecated for Windows 10, so for sensor driver testing and diagnostics on Windows 10 and later operating systems, please use the SensorInfo App from the Windows Store.
 
- 
+ 
 
 ## Configuring the Sensor Diagnostic Tool to Capture Location Data
 


### PR DESCRIPTION
Replaced all diamond char (0xA0, 0x96, 0x93...) to space char (0x20).

I enumerated these files with the following ruby script:

```ruby
require "find"

Find.find('windows-driver-docs-pr') {|f|
  next if FileTest::directory?(f)
  next unless f.downcase.end_with? ".md"
  s = File.open(f, 'r:utf-8').read
  begin
    s =~ /./
  rescue ArgumentError => e
    print "#{f}\n"
  end
}
```