### PR TITLE
Formatting fixes for virtual-hid-framework--vhf-.md

### DIFF
--- a/windows-driver-docs-pr/hid/virtual-hid-framework--vhf-.md
+++ b/windows-driver-docs-pr/hid/virtual-hid-framework--vhf-.md
@@ -12,7 +12,6 @@ ms.technology: windows-devices
 
 # Write a HID source driver by using Virtual HID Framework (VHF)
 
-
 **Summary**
 
 -   Write a Kernel-Mode Driver Framework (KMDF)HID source driver that submits HID Read Reports to the operating system.
@@ -39,12 +38,9 @@ Starting in Windows 10, the new Virtual HID Framework (VHF) eliminates the need
 
 **Note**  In this release, VHF supports a HID source driver only in kernel mode.
 
- 
-
 This topic describes the architecture of the framework, the virtual HID device tree, and the configuration scenarios.
 
 ## Virtual HID device tree
-
 
 In this image, the device tree shows the drivers and their associated device objects.
 
@@ -68,20 +64,18 @@ The Hidclass/Mshidkmdf pair enumerates [Top-Level Collections (TLC)](top-level-c
 
 **Note**  In some scenarios, a HID client might need to identify the source of HID data. For example, a system has a built-in sensor and receives data from a remote sensor of the same type. The system might want to choose one sensor to be more reliable. To differentiate between the two sensors connected to the system, the HID client queries for the container ID of the TLC. In this case, a HID source driver can provide the container ID, which is reported as the container ID of the virtual HID device by VHF.
 
- 
-
 **HID client (application)**
 
 Queries and consumes the TLCs that are reported by the HID device stack.
 
 ## <a href="" id="header-and-library-requirements-"></a>Header and library requirements
 
-
 This procedure describes how to write a simple HID source driver that reports headset buttons to the operating system. In this case, the driver that implements this code can be an existing KMDF audio driver that has been modified to act as a HID source reporting headset buttons by using VHF.
 
 1.  Include Vhf.h, included in the WDK for Windows 10.
 2.  Link to Vhflkm.lib, included in the WDK.
 3.  Create a HID Report Descriptor that your device wants to report to the operating system. In this example, the HID Report Descriptor describes the headset buttons. The report specifies a HID Input Report, size 8 bits (1 byte). The first three bits are for the headset middle, volume-up, and volume-down buttons. The remaining bits are unused.
+
     ```
     UCHAR HeadSetReportDescriptor[] = {
         0x05, 0x01,         // USAGE_PAGE (Generic Desktop Controls)
@@ -95,7 +89,7 @@ This procedure describes how to write a simple HID source driver that reports he
         0x15, 0x00,         //   LOGICAL_MINIMUM (0)
         0x25, 0x01,         //   LOGICAL_MAXIMUM (1)
         0x75, 0x01,         //   REPORT_SIZE (1)
-        0x95, 0x03,         //   REPORT_COUNT (3) 
+        0x95, 0x03,         //   REPORT_COUNT (3)
         0x81, 0x02,         //   INPUT (Data,Var,Abs)
         0x95, 0x05,         //   REPORT_COUNT (5)
         0x81, 0x03,         //   INPUT (Cnst,Var,Abs)
@@ -104,7 +98,6 @@ This procedure describes how to write a simple HID source driver that reports he
     ```
 
 ## <a href="" id="create-a-virtual-hid-device-"></a>Create a virtual HID device
-
 
 Initialize a [**VHF\_CONFIG**](https://msdn.microsoft.com/library/windows/hardware/dn925044) structure by calling the [**VHF\_CONFIG\_INIT**](https://msdn.microsoft.com/library/windows/hardware/dn925046) macro and then call the [**VhfCreate**](https://msdn.microsoft.com/library/windows/hardware/dn925036) method. The driver must call **VhfCreate** at PASSIVE\_LEVEL after the [**WdfDeviceCreate**](https://msdn.microsoft.com/library/windows/hardware/ff545926) call, typically, in the driver's [*EvtDriverDeviceAdd*](https://msdn.microsoft.com/library/windows/hardware/ff541693) callback function.
 
@@ -145,8 +138,6 @@ The virtual HID device is deleted by calling the [**VhfDelete**](https://msdn.mi
 
 **Note**  After an asynchronous operation completes, the driver must call [**VhfAsyncOperationComplete**](https://msdn.microsoft.com/library/windows/hardware/dn925060) to set the results of the operation. You can call the method from the event callback or at a later time after returning from the callback.
 
- 
-
 ```
 NTSTATUS
 VhfSourceCreateDevice(
@@ -167,7 +158,7 @@ _Inout_ PWDFDEVICE_INIT DeviceInit
 
     status = WdfDeviceCreate(&DeviceInit, &deviceAttributes, &device);
 
-    if (NT_SUCCESS(status)) 
+    if (NT_SUCCESS(status))
     {
         deviceContext = DeviceGetContext(device);
 
@@ -198,12 +189,12 @@ Error:
 
 ## <a href="" id="submit"></a>Submit the HID input report
 
-
 Submit the HID input report by calling [**VhfReadReportSubmit**](https://msdn.microsoft.com/library/windows/hardware/dn925040).
 
 Typically, a HID device sends information about state changes by sending input reports through interrupts. For example, the headset device might send a report when the state of a button changes. In such an event, the driver's interrupt service routine (ISR) is invoked. In that routine, the driver might schedule a deferred procedure call (DPC) that processes the input report and submits it to VHF, which sends the information to the operating system. By default, VHF buffers the report and the HID source driver can start submitting HID Input Reports as they come in. This and eliminates the need for the HID source driver to implement complex synchronization.
 
 The HID source driver can submit input reports by implementing the buffering policy for pending reports. To avoid duplicate buffering, the HID source driver can implement the [*EvtVhfReadyForNextReadReport*](https://msdn.microsoft.com/library/windows/hardware/dn897135) callback function and keep track of whether VHF invoked this callback. If it was previously invoked, the HID source driver can call [**VhfReadReportSubmit**](https://msdn.microsoft.com/library/windows/hardware/dn925040) to submit a report. It must wait for *EvtVhfReadyForNextReadReport* to get invoked before it can call **VhfReadReportSubmit** again.
+
     ```
     VOID
     MY_SubmitReadReport(
@@ -229,7 +220,6 @@ The HID source driver can submit input reports by implementing the buffering pol
     ```
 
 ## Delete the virtual HID device
-
 
 Delete the virtual HID device by calling [**VhfDelete**](https://msdn.microsoft.com/library/windows/hardware/dn925038).
 
@@ -262,29 +252,22 @@ _In_ WDFOBJECT DeviceObject
     }
 
 }
-
 ```
 
 ## Install the HID source driver
 
-
 In the INF file that installs the HID source driver, make sure that you declare Vhf.sys as a lower filter driver to your HID source driver by using the [**AddReg Directive**](https://msdn.microsoft.com/library/windows/hardware/ff546320).
 
 ```
-  
-[HIDVHF_Inst.NT.HW]  
-AddReg = HIDVHF_Inst.NT.AddReg  
-  
-[HIDVHF_Inst.NT.AddReg]  
-HKR,,"LowerFilters",0x00010000,"vhf"  
-  
-  
+[HIDVHF_Inst.NT.HW]
+AddReg = HIDVHF_Inst.NT.AddReg
+
+[HIDVHF_Inst.NT.AddReg]
+HKR,,"LowerFilters",0x00010000,"vhf"
 ```
 
 ## Related topics
-[Human Interface Device](https://msdn.microsoft.com/library/windows/hardware/ff543301)  
+[Human Interface Device](https://msdn.microsoft.com/library/windows/hardware/ff543301)
 
 --------------------
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20%5Bhid\hid%5D:%20Write%20a%20HID%20source%20driver%20by%20using%20Virtual%20HID%20Framework%20%28VHF%29%20%20RELEASE:%20%287/18/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
-
-


### PR DESCRIPTION
Fix code section in "Submit the HID input report" to include the function header
Remove unnecessary blank lines
Remove unnecessary spaces at the end of lines