### PR TITLE
Update writing-inf-files.md

### DIFF
--- a/windows-driver-docs-pr/install/writing-inf-files.md
+++ b/windows-driver-docs-pr/install/writing-inf-files.md
@@ -19,7 +19,7 @@ When you write an [INF file](inf-files.md) for your [driver package](driver-pack
 
 -   An INF file must use valid structure and syntax to pass driver package validation checks at the beginning of the installation process.
 
-    Use the [ChkINF](https://msdn.microsoft.com/library/windows/hardware/ff543461) tool to validate the structure and syntax of INF files.
+    Use the [INFVerif](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/infverif) tool to validate the structure and syntax of INF files.
 
 -   An INF file must contain valid INF [**SourceDisksFiles**](inf-sourcedisksfiles-section.md) and [**SourceDisksNames**](inf-sourcedisksnames-section.md) sections. Starting with Windows Vista, the operating system does not copy the driver package into the [driver store](driver-store.md) unless these sections are present and filled in correctly.
 


### PR DESCRIPTION
We should be pointing developers to infverif wherever possible as chkinf has been superseded by it.  I'm not sure if the infverif location I used is appropriate.