### PR TITLE
Fix backslash in title and description metadata

### DIFF
--- a/windows-driver-docs-pr/debugger/----comment-line-specifier-.md
+++ b/windows-driver-docs-pr/debugger/----comment-line-specifier-.md
@@ -1,6 +1,6 @@
 ---
-title: \ (Comment Line Specifier)
-description: If the asterisk ( \ ) character is at the start of a command, then the rest of the line is treated as a comment, even if a semicolon appears after it.
+title: * (Comment Line Specifier)
+description: If the asterisk (*) character is at the start of a command, then the rest of the line is treated as a comment, even if a semicolon appears after it.
 ms.assetid: 46f68e92-0758-49f2-82bb-bc4d25ddb641
 keywords: ["comment line token ( )", "(Comment Line Specifier) Windows Debugging"]
 ms.author: windowsdriverdev

--- a/windows-driver-docs-pr/debugger/---search-for-disassembly-pattern-.md
+++ b/windows-driver-docs-pr/debugger/---search-for-disassembly-pattern-.md
@@ -1,6 +1,6 @@
 ---
-title: \ (Search for Disassembly Pattern)
-description: The number sign (\ ) command searches for the specified pattern in the disassembly code.
+title: # (Search for Disassembly Pattern)
+description: The number sign (#) command searches for the specified pattern in the disassembly code.
 ms.assetid: 834dd432-94b8-4bf6-9318-09a118eab5ab
 keywords: ["(Search for Disassembly Pattern) Windows Debugging"]
 ms.author: windowsdriverdev

--- a/windows-driver-docs-pr/debugger/-locks---kdext--locks-.md
+++ b/windows-driver-docs-pr/debugger/-locks---kdext--locks-.md
@@ -1,5 +1,5 @@
 ---
-title: locks ( kdext\ .locks)
+title: !locks (!kdext*.locks)
 description: The locks extension in Kdextx86.dll and Kdexts.dll displays information about kernel ERESOURCE locks.
 ms.assetid: c1be6c6c-0028-459f-9c92-61df52cbc4b6
 keywords: ["kdext .locks extension", "ERESOURCE locks", "deadlocks", "locks ( kdext .locks) Windows Debugging"]

--- a/windows-driver-docs-pr/debugger/ctrl--.md
+++ b/windows-driver-docs-pr/debugger/ctrl--.md
@@ -1,6 +1,6 @@
 ---
-title: CTRL+\\ (Debug Current Debugger)
-description: The CTRL+\\ key launches a new instance of CDB; this new debugger takes the current debugger as its target.
+title: CTRL+\ (Debug Current Debugger)
+description: The CTRL+\ key launches a new instance of CDB; this new debugger takes the current debugger as its target.
 ms.assetid: c0c63af5-712c-47b6-8811-81e441ddb3df
 keywords: ["CTRL+\ (Debug Current Debugger) Windows Debugging"]
 ms.author: windowsdriverdev

--- a/windows-driver-docs-pr/debugger/ctrl-alt--.md
+++ b/windows-driver-docs-pr/debugger/ctrl-alt--.md
@@ -1,6 +1,6 @@
 ---
-title: CTRL+ALT+\\ (Debug Current Debugger)
-description: The CTRL+ALT+\\ key launches a new instance of CDB; this new debugger takes the current debugger as its target.
+title: CTRL+ALT+\ (Debug Current Debugger)
+description: The CTRL+ALT+\ key launches a new instance of CDB; this new debugger takes the current debugger as its target.
 ms.assetid: 0a36baa4-fe40-4498-9cf8-ae81497f1dda
 keywords: ["CTRL+ALT+\ (Debug Current Debugger) Windows Debugging"]
 ms.author: windowsdriverdev

--- a/windows-driver-docs-pr/develop/what-happens-when-you-provision-a-computer--wdk-8-0-.md
+++ b/windows-driver-docs-pr/develop/what-happens-when-you-provision-a-computer--wdk-8-0-.md
@@ -1,7 +1,7 @@
 ---
 ms.assetid: A8888EF1-5A6F-4B08-8743-27EEECD4FF72
-title: What happens when you provision a computer \(WDK 8.0\)
-description: Here we show what happens when you use version 8.0 of the Windows Driver Kit \(WDK\) to provision a target computer.
+title: What happens when you provision a computer (WDK 8.0)
+description: Here we show what happens when you use version 8.0 of the Windows Driver Kit (WDK) to provision a target computer.
 ms.author: windowsdriverdev
 ms.date: 04/20/2017
 ms.topic: article

--- a/windows-driver-docs-pr/develop/what-happens-when-you-provision-a-computer--wdk-8-1-.md
+++ b/windows-driver-docs-pr/develop/what-happens-when-you-provision-a-computer--wdk-8-1-.md
@@ -1,7 +1,7 @@
 ---
 ms.assetid: 92F58B13-3447-4715-A6D2-69E63FE04A77
-title: What happens when you provision a computer \(WDK 8.1\)
-description: Here we show what happens when you use version 8.1 of the Windows Driver Kit \(WDK\) to provision a target computer.
+title: What happens when you provision a computer (WDK 8.1)
+description: Here we show what happens when you use version 8.1 of the Windows Driver Kit (WDK) to provision a target computer.
 ms.author: windowsdriverdev
 ms.date: 04/20/2017
 ms.topic: article

--- a/windows-driver-docs-pr/devtest/where-do-i-put-the--include-statement-for-the-trace-message-header-fil.md
+++ b/windows-driver-docs-pr/devtest/where-do-i-put-the--include-statement-for-the-trace-message-header-fil.md
@@ -1,6 +1,6 @@
 ---
-title: Where do I put the \ include statement for the trace message header file
-description: Where do I put the \ include statement for the trace message header file
+title: Where do I put the #include statement for the trace message header file
+description: Where do I put the #include statement for the trace message header file
 ms.assetid: 5d8a2bb7-efe1-4cf2-9424-b63d4f17805e
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/display/-sourcedisknames--section-directives.md
+++ b/windows-driver-docs-pr/display/-sourcedisknames--section-directives.md
@@ -1,6 +1,6 @@
 ---
-title: '\ SourceDiskNames\ section directives'
-description: On Windows Vista and later, in-box INFs use the \ SourceDisksXxx\ directives. 
+title: '[SourceDiskNames] section directives'
+description: On Windows Vista and later, in-box INFs use the [SourceDisksXxx] directives. 
 ms.assetid: 0AC01548-3E53-41ED-9C7E-E33FC2DD14FD
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/display/-string--section-changes-for-localized-strings.md
+++ b/windows-driver-docs-pr/display/-string--section-changes-for-localized-strings.md
@@ -1,5 +1,5 @@
 ---
-title: '\ String\ section changes for localized strings'
+title: '[String] section changes for localized strings'
 description: This INF requirement ensures that pseudo-localized builds work. The requirement is to delineate localizable versus non-localizable strings within the strings section
 ms.assetid: F0A0C309-9FA3-4941-AF35-15CD63DB25E3
 ms.author: windowsdriverdev

--- a/windows-driver-docs-pr/display/-version--section-directives.md
+++ b/windows-driver-docs-pr/display/-version--section-directives.md
@@ -1,6 +1,6 @@
 ---
-title: '\ Version\ section directives'
-description: This topic describes \ Version\ section directives in the INF.
+title: '[Version] section directives'
+description: This topic describes [Version] section directives in the INF.
 ms.assetid: 76AC10DC-AECC-4C35-8BEE-4B2E8B06FEE0
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/display/driver-services-start-type-directive.md
+++ b/windows-driver-docs-pr/display/driver-services-start-type-directive.md
@@ -1,6 +1,6 @@
 ---
-title: Driver\\services start type directive
-description: The driver\\services start type directive is a service installation setting requirement for all display drivers. Windows Display Driver Model (WDDM) drivers are Plug and Play (PnP) and therefore must be demand started, where StartType 3.
+title: Driver\services start type directive
+description: The driver\services start type directive is a service installation setting requirement for all display drivers. Windows Display Driver Model (WDDM) drivers are Plug and Play (PnP) and therefore must be demand started, where StartType 3.
 ms.assetid: 1B34DC18-EA81-44DB-B60A-D05B685E9321
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/ifs/-optional--registering-callback-routines.md
+++ b/windows-driver-docs-pr/ifs/-optional--registering-callback-routines.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Optional\ Registering Callback Routines'
+title: '[Optional] Registering Callback Routines'
 author: windows-driver-content
-description: '\ Optional\ Registering Callback Routines'
+description: '[Optional] Registering Callback Routines'
 ms.assetid: 59d15b37-e31e-45fc-bdb0-fed6f791839c
 keywords:
 - registering callback routines

--- a/windows-driver-docs-pr/ifs/-optional--saving-a-copy-of-the-registry-path-string.md
+++ b/windows-driver-docs-pr/ifs/-optional--saving-a-copy-of-the-registry-path-string.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Optional\ Saving a Copy of the Registry Path String'
+title: '[Optional] Saving a Copy of the Registry Path String'
 author: windows-driver-content
-description: '\ Optional\ Saving a Copy of the Registry Path String'
+description: '[Optional] Saving a Copy of the Registry Path String'
 ms.assetid: cf3b8649-6fb0-4ada-816c-5c7783918b2f
 keywords:
 - RegistryPath string copies

--- a/windows-driver-docs-pr/install/--registry-subkey.md
+++ b/windows-driver-docs-pr/install/--registry-subkey.md
@@ -1,6 +1,6 @@
 ---
-title: '\ Registry Subkey'
-description: '\ Registry Subkey'
+title: '* Registry Subkey'
+description: '* Registry Subkey'
 ms.assetid: 19b72c64-5a64-4655-b922-4a4bca162b32
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/install/hklm-system-currentcontrolset-control-registry-tree.md
+++ b/windows-driver-docs-pr/install/hklm-system-currentcontrolset-control-registry-tree.md
@@ -1,6 +1,6 @@
 ---
-title: HKLM\\SYSTEM\\CurrentControlSet\\Control Registry Tree
-description: HKLM\\SYSTEM\\CurrentControlSet\\Control Registry Tree
+title: HKLM\SYSTEM\CurrentControlSet\Control Registry Tree
+description: HKLM\SYSTEM\CurrentControlSet\Control Registry Tree
 ms.assetid: 58eacd32-425d-4224-8d37-21e2caf124cf
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/install/hklm-system-currentcontrolset-enum-registry-tree.md
+++ b/windows-driver-docs-pr/install/hklm-system-currentcontrolset-enum-registry-tree.md
@@ -1,6 +1,6 @@
 ---
-title: HKLM\\SYSTEM\\CurrentControlSet\\Enum Registry Tree
-description: HKLM\\SYSTEM\\CurrentControlSet\\Enum Registry Tree
+title: HKLM\SYSTEM\CurrentControlSet\Enum Registry Tree
+description: HKLM\SYSTEM\CurrentControlSet\Enum Registry Tree
 ms.assetid: 9de3ca54-d23f-4ee6-a638-27e52a60dfdd
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/install/hklm-system-currentcontrolset-hardwareprofiles-registry-tree.md
+++ b/windows-driver-docs-pr/install/hklm-system-currentcontrolset-hardwareprofiles-registry-tree.md
@@ -1,6 +1,6 @@
 ---
-title: HKLM\\SYSTEM\\CurrentControlSet\\HardwareProfiles Registry Tree
-description: HKLM\\SYSTEM\\CurrentControlSet\\HardwareProfiles Registry Tree
+title: HKLM\SYSTEM\CurrentControlSet\HardwareProfiles Registry Tree
+description: HKLM\SYSTEM\CurrentControlSet\HardwareProfiles Registry Tree
 ms.assetid: 548d7a50-b3b1-4413-8898-9ed13bcbdcfc
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/install/hklm-system-currentcontrolset-services-registry-tree.md
+++ b/windows-driver-docs-pr/install/hklm-system-currentcontrolset-services-registry-tree.md
@@ -1,6 +1,6 @@
 ---
-title: HKLM\\SYSTEM\\CurrentControlSet\\Services Registry Tree
-description: HKLM\\SYSTEM\\CurrentControlSet\\Services Registry Tree
+title: HKLM\SYSTEM\CurrentControlSet\Services Registry Tree
+description: HKLM\SYSTEM\CurrentControlSet\Services Registry Tree
 ms.assetid: c966b029-8171-4db7-9fbb-3a4222ff184b
 ms.author: windowsdriverdev
 ms.date: 04/20/2017

--- a/windows-driver-docs-pr/print/-define-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-define-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Define Preprocessor Directive'
+title: '#Define Preprocessor Directive'
 author: windows-driver-content
-description: '\ Define Preprocessor Directive'
+description: '#Define Preprocessor Directive'
 ms.assetid: e2fab866-dc81-4e4a-bac7-291d0b803962
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-disableppdirective-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-disableppdirective-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ DisablePPDirective Preprocessor Directive'
+title: '#DisablePPDirective Preprocessor Directive'
 author: windows-driver-content
-description: '\ DisablePPDirective Preprocessor Directive'
+description: '#DisablePPDirective Preprocessor Directive'
 ms.assetid: 5f85a6b1-a72f-45e2-901a-7bce94b4793c
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-else-conditional-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-else-conditional-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Else Conditional Preprocessor Directive'
+title: '#Else Conditional Preprocessor Directive'
 author: windows-driver-content
-description: '\ Else Conditional Preprocessor Directive'
+description: '#Else Conditional Preprocessor Directive'
 ms.assetid: 3a8ddc60-1db9-4db0-9e55-405c88b84849
 keywords:
 - preprocessor directives WDK GDL , conditional directives

--- a/windows-driver-docs-pr/print/-elseifdef-conditional-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-elseifdef-conditional-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Elseifdef Conditional Preprocessor Directive'
+title: '#Elseifdef Conditional Preprocessor Directive'
 author: windows-driver-content
-description: '\ Elseifdef Conditional Preprocessor Directive'
+description: '#Elseifdef Conditional Preprocessor Directive'
 ms.assetid: 0239696a-ea6a-4fd4-b4ca-870a87022c81
 keywords:
 - preprocessor directives WDK GDL , conditional directives

--- a/windows-driver-docs-pr/print/-enableppdirective-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-enableppdirective-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ EnablePPDirective Preprocessor Directive'
+title: '#EnablePPDirective Preprocessor Directive'
 author: windows-driver-content
-description: '\ EnablePPDirective Preprocessor Directive'
+description: '#EnablePPDirective Preprocessor Directive'
 ms.assetid: aebb11ec-b281-461e-b3fd-65e9b2773049
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-endif-conditional-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-endif-conditional-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Endif Conditional Preprocessor Directive'
+title: '#Endif Conditional Preprocessor Directive'
 author: windows-driver-content
-description: '\ Endif Conditional Preprocessor Directive'
+description: '#Endif Conditional Preprocessor Directive'
 ms.assetid: dfbfdb4a-955b-4ccf-b496-c8c5ddc42d2b
 keywords:
 - preprocessor directives WDK GDL , conditional directives

--- a/windows-driver-docs-pr/print/-ifdef-conditional-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-ifdef-conditional-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Ifdef Conditional Preprocessor Directive'
+title: '#Ifdef Conditional Preprocessor Directive'
 author: windows-driver-content
-description: '\ Ifdef Conditional Preprocessor Directive'
+description: '#Ifdef Conditional Preprocessor Directive'
 ms.assetid: 57c59bf8-19bd-47bc-858d-ea500d44fb4d
 keywords:
 - preprocessor directives WDK GDL , conditional directives

--- a/windows-driver-docs-pr/print/-include-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-include-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Include Preprocessor Directive'
+title: '#Include Preprocessor Directive'
 author: windows-driver-content
-description: '\ Include Preprocessor Directive'
+description: '#Include Preprocessor Directive'
 ms.assetid: 6c3e4de7-2007-4a1a-bdb0-fd5b2b64f489
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-precompiled-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-precompiled-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ PreCompiled Preprocessor Directive'
+title: '#PreCompiled Preprocessor Directive'
 author: windows-driver-content
-description: '\ PreCompiled Preprocessor Directive'
+description: '#PreCompiled Preprocessor Directive'
 ms.assetid: 639db56d-7677-4d21-8329-a0f35d68151e
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-setppprefix-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-setppprefix-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ SetPPPrefix Preprocessor Directive'
+title: '#SetPPPrefix Preprocessor Directive'
 author: windows-driver-content
-description: '\ SetPPPrefix Preprocessor Directive'
+description: '#SetPPPrefix Preprocessor Directive'
 ms.assetid: 3520aa66-1090-40db-9c9f-cfba0e6e2bee
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-undefine-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-undefine-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ Undefine Preprocessor Directive'
+title: '#Undefine Preprocessor Directive'
 author: windows-driver-content
-description: '\ Undefine Preprocessor Directive'
+description: '#Undefine Preprocessor Directive'
 ms.assetid: 78f6a895-2c30-4a6f-8916-4c18e22e4e70
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/print/-undefineprefix-preprocessor-directive.md
+++ b/windows-driver-docs-pr/print/-undefineprefix-preprocessor-directive.md
@@ -1,7 +1,7 @@
 ---
-title: '\ UndefinePrefix Preprocessor Directive'
+title: '#UndefinePrefix Preprocessor Directive'
 author: windows-driver-content
-description: '\ UndefinePrefix Preprocessor Directive'
+description: '#UndefinePrefix Preprocessor Directive'
 ms.assetid: 7c99c2cf-6609-4fec-ae21-1477699ba5c8
 keywords:
 - preprocessor directives WDK GDL , keywords

--- a/windows-driver-docs-pr/taef/authoring-tests-in-c-.md
+++ b/windows-driver-docs-pr/taef/authoring-tests-in-c-.md
@@ -1,6 +1,6 @@
 ---
-title: Authoring Tests in C\
-description: Authoring Tests in C\
+title: Authoring Tests in C#
+description: Authoring Tests in C#
 ms.assetid: 4DD1D673-FEAF-44a4-8BAD-0E55318DC64B
 ms.author: windowsdriverdev
 ms.date: 04/20/2017


### PR DESCRIPTION
In title and description metadata, replaced `\` with appropriate symbol.