### PR TITLE
Update building-a-basic-v4-printer-driver.md

### DIFF
--- a/windows-driver-docs-pr/print/building-a-basic-v4-printer-driver.md
+++ b/windows-driver-docs-pr/print/building-a-basic-v4-printer-driver.md
@@ -28,7 +28,7 @@ The instructions in this topic will focus on the steps required for building a d
 
 3. In the middle pane, select **Printer Driver V4**.
 
-4. Type a name for your driver in the **Name** field, and then click **OK**. For example, you could type *MyV4PrintDriver*.
+4. Type a name for your driver in the **Name** field, and then click **OK**. For example, you could type *MyV4PrinterDriver*.
 
 5. In the **Create a v4 Print Driver Wizard**, under **Choose the driver rendering type:**, click **V4 print driver with custom rendering filters (accepts XPS only)**.
 
@@ -38,24 +38,24 @@ The instructions in this topic will focus on the steps required for building a d
 
 8. In the **Setup information (page 2)** section of the Wizard, leave all options at their default settings, then click **Next**.
 
-Microsoft Visual Studio uses the preceding selections to generate the project files for *MyV4PrintDriver*.
+Microsoft Visual Studio uses the preceding selections to generate the project files for *MyV4PrinterDriver*.
 
 ## Verify the generated driver files
 
 
-1. Navigate to the folder for the generated driver files. For example, if you named your project *MyV4PrintDriver*, then by default, the files would be saved to the following location: *My Documents &gt; Visual Studio 2013 &gt; Projects &gt; MyV4PrintDriver &gt; MyV4PrintDriver*.
+1. Navigate to the folder for the generated driver files. For example, if you named your project *MyV4PrinterDriver*, then by default, the files would be saved to the following location: *My Documents &gt; Visual Studio 2013 &gt; Projects &gt; MyV4PrinterDriver &gt; MyV4PrinterDriver*.
 
 2. Verify that the folder contains the following files:
 
 | File name                                              | File type                                                  |
 |--------------------------------------------------------|------------------------------------------------------------|
-| MyV4PrintDriver-manifest.ini                           | Configuration settings file (a.k.a. print driver manifest) |
-| MyV4PrintDriver.gpd                                    | Printer description file                                   |
-| MyV4PrintDriverPackage-Intellisense.js                 | JavaScript file for Intellisense                           |
-| MyV4PrintDriverRenderFilter-Intellisense-Windows8.1.js | JavaScript file for Intellisense                           |
-| MyV4PrintDriverRenderFilter.ini                        | Setup information file                                     |
-| MyV4PrintDriverRenderFilter.vcxproj.filters            | C++ Project filters file                                   |
-| MyV4PrintDriverRenderFilter.vcxproj                    | Project file                                               |
+| MyV4PrinterDriver-manifest.ini                           | Configuration settings file (a.k.a. print driver manifest) |
+| MyV4PrinterDriver.gpd                                    | Printer description file                                   |
+| MyV4PrinterDriverPackage-Intellisense.js                 | JavaScript file for Intellisense                           |
+| MyV4PrinterDriverRenderFilter-Intellisense-Windows8.1.js | JavaScript file for Intellisense                           |
+| MyV4PrinterDriverRenderFilter.ini                        | Setup information file                                     |
+| MyV4PrinterDriverRenderFilter.vcxproj.filters            | C++ Project filters file                                   |
+| MyV4PrinterDriverRenderFilter.vcxproj                    | Project file                                               |
 
  
 
@@ -79,7 +79,7 @@ Type the following lines:
 MyV4PrinterDriver.gpd=1
 MyV4PrinterDriver-manifest.ini=1
 MyV4PrinterDriverRenderFilter-PipelineConfig.xml=1
-MyV4PrintDriverRenderFilter.dll=1
+MyV4PrinterDriverRenderFilter.dll=1
 Create a section called \[DriverInstall\] at the bottom of the INF file, and configure it
 
 Type the following line in the newly created \[DriverInstall\] section:
@@ -92,13 +92,13 @@ Type the following lines in the newly created \[DriverFiles\] section:
 MyV4PrinterDriver.gpd
 MyV4PrinterDriver-manifest.ini
 MyV4PrinterDriverRenderFilter-PipelineConfig.xml
-MyV4PrintDriverRenderFilter.dll
+MyV4PrinterDriverRenderFilter.dll
 Configure the \[Standard.NT$ARCH$\] section
 
 Type the following lines to target a particular printer model. For example, if the model of your printer is Fabrikam1234, then you would type the following:
 
-“Model name”=DriverInstall, USBPRINT\\Fabrikam1234
-“Model name”=DriverInstall, WSDPRINT\\Fabrikam1234
+"Model name"=DriverInstall, USBPRINT\\Fabrikam1234
+"Model name"=DriverInstall, WSDPRINT\\Fabrikam1234
 Add **PrinterDriverID** to the INF file
 
 1. In Visual Studio, in the Solution Explorer, expand the *MyV4PrinterDriver Package* node.
@@ -107,16 +107,16 @@ Add **PrinterDriverID** to the INF file
 
 3. In the INF file, in the \[Standard.NT$ARCH$\] section, type the following line:
 
-“Model name”=DriverInstall,
+"Model name"=DriverInstall,
 And then after the comma, paste the GUID that you copied in the preceding step. The completed \[Standard.NT$ARCH$\] section should like the following:
-“Model name”=DriverInstall, USBPRINT\\Fabrikam1234
-“Model name”=DriverInstall, WSDPRINT\\Fabrikam1234
-“Model name”=DriverInstall, {GUID}
+"Model name"=DriverInstall, USBPRINT\\Fabrikam1234
+"Model name"=DriverInstall, WSDPRINT\\Fabrikam1234
+"Model name"=DriverInstall, {GUID}
 Configure the \[String\] section
 
 1. Type the following, to provide a manufacturer’s name for the target printer. For example, if your company’s name is My Company, you would type the following:
 
-**ManufacturerName** = “My Company”
+**ManufacturerName** = "My Company"
 2. Save the INF file.
 
 When you complete the INF file, it should look like the following. Note that in place of the *{GUID}* entry that is shown in this sample INF file, your INF file should contain the GUID that you retrieved using the steps in the preceding *Add PrinterDriverID to the INF file* section.
@@ -141,15 +141,15 @@ DefaultDestDir = 66000
 MyV4PrinterDriver.gpd=1
 MyV4PrinterDriver-manifest.ini=1
 MyV4PrinterDriverRenderFilter-PipelineConfig.xml=1
-MyV4PrintDriverRenderFilter.dll=1
+MyV4PrinterDriverRenderFilter.dll=1
 
 [Manufacturer]
 %ManufacturerName%=Standard,NT$ARCH$
 
 [Standard.NT$ARCH$]
-“Model name”=DriverInstall, USBPRINT\Fabrikam1234
-“Model name”=DriverInstall, WSDPRINT\Fabrikam1234
-“Model name”=DriverInstall, {GUID}
+"Model name"=DriverInstall, USBPRINT\Fabrikam1234
+"Model name"=DriverInstall, WSDPRINT\Fabrikam1234
+"Model name"=DriverInstall, {GUID}
 
 [DriverInstall]
 CopyFiles=DriverFiles
@@ -158,7 +158,7 @@ CopyFiles=DriverFiles
 MyV4PrinterDriver.gpd
 MyV4PrinterDriver-manifest.ini
 MyV4PrinterDriverRenderFilter-PipelineConfig.xml
-MyV4PrintDriverRenderFilter.dll
+MyV4PrinterDriverRenderFilter.dll
 
 [Strings]
 ManufacturerName="My Company"
@@ -176,7 +176,7 @@ DiskName="MyV4PrinterDriver Installation Disk"
 
 -   Click **Enable deployment**
 -   Check **Remove previous driver versions before deployment**
--   Ensure that the **Target Computer Name** is configured. If it isn’t, click “…” and follow the prompts in the **Computer Configuration** wizard to set up a remote target computer
+-   Ensure that the **Target Computer Name** is configured. If it isn’t, click "…" and follow the prompts in the **Computer Configuration** wizard to set up a remote target computer
 -   Select **Install and Verify**, then select **Default Printer Driver Package Installation Task** from the drop-down box
 -   Type the name of the driver in the **Optional Arguments** field (without any quotes around the name)
 -   Click **OK**
@@ -213,7 +213,7 @@ Create a print queue using either plug-and-play or the Add Printer Wizard.
 For more information about INF files for the v4 printer driver, see [V4 Driver INF](v4-driver-inf.md).
 
 **Note**  
-In addition to the files in the preceding table, notice that a *MyV4PrintDriver Render Filter* folder was created. This is the render filter project template and it provides a good foundation for building an XPS rendering filter and an XPS filter pipeline configuration file. For more information about XPS rendering filters, see [XPSDrv Render Module](xpsdrv-render-module.md), and to see an example of an XPS rendering filter, see the [XPS Rasterization Filter Service](http://go.microsoft.com/fwlink/p/?LinkId=617951) sample.
+In addition to the files in the preceding table, notice that a *MyV4PrinterDriver Render Filter* folder was created. This is the render filter project template and it provides a good foundation for building an XPS rendering filter and an XPS filter pipeline configuration file. For more information about XPS rendering filters, see [XPSDrv Render Module](xpsdrv-render-module.md), and to see an example of an XPS rendering filter, see the [XPS Rasterization Filter Service](http://go.microsoft.com/fwlink/p/?LinkId=617951) sample.
 
  
 


### PR DESCRIPTION
Fix incorrect name of the sample project: sometimes it referred as "MyV4PrinterDriver" and sometimes as "MyV4PrintDriver". I changed sample project name to "MyV4PrinterDriver".
Also, I changed “ to the " since it caused the incorrect name of the printer in case of “Model name” usage.