### PR TITLE
Remove Important note about Sysdev

### DIFF
--- a/windows-driver-docs-pr/dashboard/attestation-signing-a-kernel-driver-for-public-release.md
+++ b/windows-driver-docs-pr/dashboard/attestation-signing-a-kernel-driver-for-public-release.md
@@ -13,10 +13,6 @@ ms.technology: windows-devices
 
 
 This topic describes how to sign a driver using attestation signing.
-
-> [!IMPORTANT]
-> You must still use [Hardware Dev Center (Sysdev)](dashboard-services.md) to sign a driver using attestation signing until driver signing is available through the new Windows Hardware Dev Center dashboard.
-
  
 
 > [!Note]  


### PR DESCRIPTION
According to https://sysdev.microsoft.com/en-US/Hardware/CompatibilityPlaylists/DevCenter.aspx this important note seems to be obsolete as of 01/17/2017. This has caused some unneccessary confusion in my case as due to this note I though I have to create Sysdev account. Creating new accounts using company email addresses in Sysdev is complicated due to cleaning up the Azure/Microsoft account overlap. I believe removing this obsolete warning will save others from this confusion.