### PR TITLE
Update bug-check-0x7e--system-thread-exception-not-handled.md

### DIFF
--- a/windows-driver-docs-pr/debugger/bug-check-0x7e--system-thread-exception-not-handled.md
+++ b/windows-driver-docs-pr/debugger/bug-check-0x7e--system-thread-exception-not-handled.md
@@ -1,8 +1,8 @@
 ---
-title: (Developer Content) Bug Check 0x7E SYSTEM_THREAD_EXCEPTION_NOT_HANDLED
+title: Bug Check 0x7E SYSTEM_THREAD_EXCEPTION_NOT_HANDLED
 description: The SYSTEM_THREAD_EXCEPTION_NOT_HANDLED bug check has a value of 0x0000007E. This bug check indicates that a system thread generated an exception that the error handler did not catch.
 ms.assetid: 2ecea74f-21d6-4436-beed-d8cf8ef6b169
-keywords: ["(Developer Content) Bug Check 0x7E SYSTEM_THREAD_EXCEPTION_NOT_HANDLED", "SYSTEM_THREAD_EXCEPTION_NOT_HANDLED"]
+keywords: ["Bug Check 0x7E SYSTEM_THREAD_EXCEPTION_NOT_HANDLED", "SYSTEM_THREAD_EXCEPTION_NOT_HANDLED"]
 ms.author: windowsdriverdev
 ms.date: 05/23/2017
 ms.topic: article
@@ -16,7 +16,7 @@ api_type:
 - NA
 ---
 
-# (Developer Content) Bug Check 0x7E: SYSTEM\_THREAD\_EXCEPTION\_NOT\_HANDLED
+# Bug Check 0x7E: SYSTEM\_THREAD\_EXCEPTION\_NOT\_HANDLED
 
 
 The SYSTEM\_THREAD\_EXCEPTION\_NOT\_HANDLED bug check has a value of 0x0000007E. This bug check indicates that a system thread generated an exception that the error handler did not catch.


### PR DESCRIPTION
The extra "(Developer Content)" breaks index in chm file. Other bug check codes does not have this word.