### PR TITLE
Fix '\<' formatting

### DIFF
--- a/windows-driver-docs-pr/debugger/dbh-commands.md
+++ b/windows-driver-docs-pr/debugger/dbh-commands.md
@@ -248,7 +248,7 @@ The following table lists the commands that display and search for symbols.
 </tr>
 <tr class="even">
 <td align="left"><p><strong>elines</strong> [<em>Source</em> [<em>Obj</em>]]</p></td>
-<td align="left"><p>Enumerates all source lines matching the specified source mask and object mask. <em>Source</em> specifies the name of the source file, including the absolute path and file name extension. <em>Obj</em> specifies the name of the object file, including the relative path and file name extension. Both <em>Source</em> and <em>Obj</em> may contain a variety of wildcard characters and specifiers; see [String Wildcard Syntax](string-wildcard-syntax.md) for details. If a parameter is omitted this is equivalent to using the asterisk (<strong>*</strong>) wildcard. If you do not wish to specify path information, prefix the file name with <strong>*\</strong> to indicate a wildcard path.</p></td>
+<td align="left"><p>Enumerates all source lines matching the specified source mask and object mask. <em>Source</em> specifies the name of the source file, including the absolute path and file name extension. <em>Obj</em> specifies the name of the object file, including the relative path and file name extension. Both <em>Source</em> and <em>Obj</em> may contain a variety of wildcard characters and specifiers; see [String Wildcard Syntax](string-wildcard-syntax.md) for details. If a parameter is omitted this is equivalent to using the asterisk (<strong>\*</strong>) wildcard. If you do not wish to specify path information, prefix the file name with <strong>\*\\</strong> to indicate a wildcard path.</p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p><strong>index</strong> <em>Value</em></p></td>

--- a/windows-driver-docs-pr/debugger/gflags-details.md
+++ b/windows-driver-docs-pr/debugger/gflags-details.md
@@ -66,36 +66,36 @@ GFlags settings that are saved between sessions are stored in the registry. You 
 <tbody>
 <tr class="odd">
 <td align="left"><p>Systemwide settings (&quot;Registry&quot;)</p></td>
-<td align="left"><p>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\<strong>GlobalFlag</strong></p></td>
+<td align="left"><p>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\\<strong>GlobalFlag</strong></p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Program-specific settings (&quot;Image file&quot;) for all users of the computer.</p></td>
-<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<em>ImageFileName</em>\<strong>GlobalFlag</strong></p></td>
+<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<em>ImageFileName</em>\\<strong>GlobalFlag</strong></p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Silent exit settings for a specific program (&quot;Silent Process Exit&quot;) for all users of the computer.</p></td>
-<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\<em>ImageFileName</em></p></td>
+<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\\<em>ImageFileName</em></p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Page heap options for an image file for all users of the computer</p></td>
-<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<em>ImageFileName</em>\<strong>PageHeapFlags</strong></p></td>
+<td align="left"><p>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<em>ImageFileName</em>\\<strong>PageHeapFlags</strong></p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>User mode stack trace database size (<strong>tracedb</strong>)</p></td>
-<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<em>ImageFileName</em>\<strong>StackTraceDatabaseSizeInMb</strong></p></td>
+<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<em>ImageFileName</em>\\<strong>StackTraceDatabaseSizeInMb</strong></p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Create user mode stack trace database (ust, 0x1000) for an image file</p></td>
-<td align="left"><p>Windows adds the image file name to the value of the USTEnabled registry entry (HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<strong>USTEnabled</strong>).</p></td>
+<td align="left"><p>Windows adds the image file name to the value of the USTEnabled registry entry (HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<strong>USTEnabled</strong>).</p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Load image using large pages if possible</p></td>
-<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<em>ImageFileName</em>\<strong>UseLargePages</strong>.</p></td>
+<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<em>ImageFileName</em>\\<strong>UseLargePages</strong>.</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Special Pool</p>
 <p>(Kernel Special Pool Tag)</p></td>
-<td align="left"><p>HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\<strong>PoolTag</strong></p></td>
+<td align="left"><p>HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\\<strong>PoolTag</strong></p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Verify Start / Verify End</p></td>
@@ -103,11 +103,11 @@ GFlags settings that are saved between sessions are stored in the registry. You 
 </tr>
 <tr class="even">
 <td align="left"><p>Debugger for an image file</p></td>
-<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<em>ImageFileName</em>\<strong>Debugger</strong></p></td>
+<td align="left"><p>HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\\<em>ImageFileName</em>\\<strong>Debugger</strong></p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Object Reference Tracing</p></td>
-<td align="left"><p>HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Kernel\<strong>ObTraceProcessName</strong>, <strong>ObTracePermanent</strong> and <strong>ObTracePoolTags</strong></p></td>
+<td align="left"><p>HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Kernel\\<strong>ObTraceProcessName</strong>, <strong>ObTracePermanent</strong> and <strong>ObTracePoolTags</strong></p></td>
 </tr>
 </tbody>
 </table>

--- a/windows-driver-docs-pr/devtest/message-compiler-task.md
+++ b/windows-driver-docs-pr/devtest/message-compiler-task.md
@@ -22,7 +22,7 @@ The following example shows how to edit the metadata in the .vcxproj file.
 <ItemGroup>
     <MessageCompile Include="a.mc">
       <GenerateBaselineResource>true</GenerateBaselineResource>
-      <BaselineResourcePath>c:\test\\</BaselineResourcePath>
+      <BaselineResourcePath>c:\test\</BaselineResourcePath>
     </MessageCompile>
 </ItemGroup>
 ```

--- a/windows-driver-docs-pr/devtest/tracewpp-task.md
+++ b/windows-driver-docs-pr/devtest/tracewpp-task.md
@@ -31,7 +31,7 @@ The following example shows how to edit the metadata in the .vcxproj file.
     <ClCompile Include="b.c">
         <WppEnabled>true</WppEnabled>
         <WppKernelMode>true</WppKernelMode>
-        <WppAdditionalIncludeDirectories>c:\test\\</WppAdditionalIncludeDirectories>
+        <WppAdditionalIncludeDirectories>c:\test\</WppAdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile Include="test1.c" />
     <ClCompile Include="test2.c">

--- a/windows-driver-docs-pr/devtest/using-wpp-recorder.md
+++ b/windows-driver-docs-pr/devtest/using-wpp-recorder.md
@@ -259,7 +259,7 @@ In another example, you have two devices, and one device sends more trace messag
 The system defines maximum and minimum buffer sizes in the registry. You can set these values appropriately to conserve memory and configure logging capabilities.
 
 ```
-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\\<serviceName>\Parameters
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\<serviceName>\Parameters
    WppRecorder_PerBufferMinBytes
    Data type
    REG_DWORD

--- a/windows-driver-docs-pr/ieee/modifying-the-default-behavior-of-the-ieee-1394-bus-driver.md
+++ b/windows-driver-docs-pr/ieee/modifying-the-default-behavior-of-the-ieee-1394-bus-driver.md
@@ -28,7 +28,7 @@ The following registry location contains the global 1394 registry values:
 
 The following registry location contains the individual 1394 controller registry values:
 
-`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class \{6BDD1FC1-810F-11D0-BEC7-08002BE2092F}\\<NNNN>`
+`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class \{6BDD1FC1-810F-11D0-BEC7-08002BE2092F}\<NNNN>`
 
 `<NNNN>` represents the instance identification number for each 1394 controller.
 

--- a/windows-driver-docs-pr/ifs/support-for-unc-naming-and-mup.md
+++ b/windows-driver-docs-pr/ifs/support-for-unc-naming-and-mup.md
@@ -239,7 +239,7 @@ Changes to the ProviderOrder registry value require a reboot to take effect in M
 MUP uses each provider name listed to find the provider's registry key under the following registry key:
 
 ```
-HKLM\System\CurrentControlSet\Services\\<ProviderName>
+HKLM\System\CurrentControlSet\Services\<ProviderName>
 ```
 
 MUP then reads the DeviceName value under the NetworkProvider subkey to find the device name with which the provider will register. When the provider actually registers, MUP matches the device name passed in with the list of device names of known providers and places the provider in an ordered list for the purposes of prefix resolution. The order of providers in this list is based on the order specified in the ProviderOrder registry value discussed above.

--- a/windows-driver-docs-pr/install/device-instance-ids.md
+++ b/windows-driver-docs-pr/install/device-instance-ids.md
@@ -19,7 +19,7 @@ A device instance ID is a system-supplied device identification string that uniq
 
 The format of this string consists of an [instance ID](instance-ids.md) concatenated to a [device ID](device-ids.md), as follows:
 
-`<device-ID>\\<instance-specific-ID>`
+`<device-ID>\<instance-specific-ID>`
 
 The number of characters of a device instance ID, excluding a NULL-terminator, must be less than MAX\_DEVICE\_ID\_LEN. This constraint applies to the sum of the lengths of all the fields and "\\" field separator between the *device ID* and *instance-specific-ID* fields.
 

--- a/windows-driver-docs-pr/install/device-metadata-store.md
+++ b/windows-driver-docs-pr/install/device-metadata-store.md
@@ -17,7 +17,7 @@ ms.technology: windows-devices
 The device metadata store is the directory where device metadata packages are stored on the local computer. The device metadata store is accessed from the following directory:
 
 ```
-%PROGRAMDATA%\Microsoft\Windows\DeviceMetadataStore\\<locale>
+%PROGRAMDATA%\Microsoft\Windows\DeviceMetadataStore\<locale>
 ```
 
 The &lt;locale&gt; subdirectory represents the locale of the device metadata package. The name of this subdirectory can be in the following format:

--- a/windows-driver-docs-pr/install/elam-driver-requirements.md
+++ b/windows-driver-docs-pr/install/elam-driver-requirements.md
@@ -89,7 +89,7 @@ The two callback types have unique context structures that provide additional in
 The malware signature data is determined by the AM ISV, but should include, at a minimum, an approved list of driver hashes. The signature data is stored in the registry in a new “Early Launch Drivers” hive under HKLM that is loaded by Winload. Each AM driver has a unique key in which to store their signature binary large object (BLOB). The registry path and key has the format:
 
 ```
-HKLM\ELAM\\<VendorName>\
+HKLM\ELAM\<VendorName>\
 ```
 
 Within the key, the vendor is free to define and use any of the values.

--- a/windows-driver-docs-pr/install/installing-device-metadata-packages-to-an-offline-windows-image.md
+++ b/windows-driver-docs-pr/install/installing-device-metadata-packages-to-an-offline-windows-image.md
@@ -15,7 +15,7 @@ ms.technology: windows-devices
 Computer OEMs can add device metadata packages to an offline image of Windows by copying the packages to the local device metadata store. This store is in the following location:
 
 ```
-%PROGRAMDATA%\Microsoft\Windows\DeviceMetadataStore\\<locale>
+%PROGRAMDATA%\Microsoft\Windows\DeviceMetadataStore\<locale>
 ```
 
 You must first create the *&lt;locale&gt;* subdirectory based on the target locale of the device metadata package. Then you must copy the metadata package to the appropriate *&lt;locale&gt;* subdirectory.

--- a/windows-driver-docs-pr/kernel/object-names.md
+++ b/windows-driver-docs-pr/kernel/object-names.md
@@ -60,11 +60,11 @@ For example, the components of the object name can be described as follows.
 <td><p>Device object representing the C: drive.</p></td>
 </tr>
 <tr class="odd">
-<td><p><strong>\DosDevices\C:\</strong> <em>Directory</em></p></td>
+<td><p><strong>\DosDevices\C:\\</strong> <em>Directory</em></p></td>
 <td><p>File object representing the directory named C:\Directory.</p></td>
 </tr>
 <tr class="even">
-<td><p><strong>\DosDevices\C:\</strong> <em>Directory</em> \ <em>File</em></p></td>
+<td><p><strong>\DosDevices\C:\\</strong> <em>Directory</em> \ <em>File</em></p></td>
 <td><p>File object representing the file named C:\Directory\File.</p></td>
 </tr>
 </tbody>

--- a/windows-driver-docs-pr/network/keywords-that-can-be-edited.md
+++ b/windows-driver-docs-pr/network/keywords-that-can-be-edited.md
@@ -23,12 +23,12 @@ NDIS 6.0 and later versions of NDIS provide standardized keywords that can be ed
 The following example shows an INF file definition for a keyword that can be edited.
 
 ```
-HKR, Ndi\params\\<SubkeyName>,ParamDesc, 0, "<ParamDesc>"
-HKR, Ndi\params\\<SubkeyName>,Type, 0, "int"
-HKR, Ndi\params\\<SubkeyName>,Default, 0, "<IHV defined>"
-HKR, Ndi\params\\<SubkeyName>,Optional, 0, "0"
-HKR, Ndi\params\\<SubkeyName>,Min, 0, "0"
-HKR, Ndi\params\\<SubkeyName>,Max, 0, "<IHV defined>"
+HKR, Ndi\params\<SubkeyName>,ParamDesc, 0, "<ParamDesc>"
+HKR, Ndi\params\<SubkeyName>,Type, 0, "int"
+HKR, Ndi\params\<SubkeyName>,Default, 0, "<IHV defined>"
+HKR, Ndi\params\<SubkeyName>,Optional, 0, "0"
+HKR, Ndi\params\<SubkeyName>,Min, 0, "0"
+HKR, Ndi\params\<SubkeyName>,Max, 0, "<IHV defined>"
 ```
 
 The standard keywords that can be edited are:

--- a/windows-driver-docs-pr/network/mobile-broadband-device-firmware-update.md
+++ b/windows-driver-docs-pr/network/mobile-broadband-device-firmware-update.md
@@ -52,7 +52,7 @@ This section provides a sample INF that is part of the WU package. The key point
 
 -   The firmware binaries are independent of the UMDF driver.
 -   The firmware binaries are located a well-known, pre-defined location as shown below to filename collisions. The binaries cannot be not be executable files containing PE/COFF headers.
--   `%windir%\Firmware\\<IHVCompanyName>\\<UniqueBinaryName>.bin`
+-   `%windir%\Firmware\<IHVCompanyName>\<UniqueBinaryName>.bin`
 -   The UMDF driver is aware of this predefined well-known location.
 -   The sample INF template below has highlighted items that need to be filled by the IHV.
 

--- a/windows-driver-docs-pr/network/wi-fi-hotspot-offloading-plugin.md
+++ b/windows-driver-docs-pr/network/wi-fi-hotspot-offloading-plugin.md
@@ -184,7 +184,7 @@ The following values must be saved under the registry key:
 
 ### Data files that contain connection-specific information such as a list of SSIDs, encrypted credentials, etc. [Optional]
 
-The data files should be saved under: Data\SharedData\HotspotHost\Plugins\<ProviderName>.
+The data files should be saved under: `Data\SharedData\HotspotHost\Plugins\<ProviderName>`.
 
 --------------------
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20%5Bprint\print%5D:%20Slicer%20settings%20%20RELEASE:%20%289/2/2016%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")

--- a/windows-driver-docs-pr/print/pcl-separator-page-escape-codes.md
+++ b/windows-driver-docs-pr/print/pcl-separator-page-escape-codes.md
@@ -35,11 +35,11 @@ The escape codes shown in the following table can be used when you create a PCL 
 </thead>
 <tbody>
 <tr class="odd">
-<td><p>\</p></td>
+<td><p>\\</p></td>
 <td><p>The first line of the separator file must contain only this character. The separator file interpreter reads the separator file command as a delimiter.</p></td>
 </tr>
 <tr class="even">
-<td><p>\<em>n</em></p></td>
+<td><p>\\<em>n</em></p></td>
 <td><p>Skips the number of lines specified by <em>n</em> (from 0 through 9). Skipping 0 lines moves printing to the next line.</p></td>
 </tr>
 <tr class="odd">

--- a/windows-driver-docs-pr/usbcon/headers-and-libraries-for-a-usb-client-driver.md
+++ b/windows-driver-docs-pr/usbcon/headers-and-libraries-for-a-usb-client-driver.md
@@ -164,33 +164,33 @@ To find the header and library for a specific device driver interface (DDI), con
 <tbody>
 <tr class="odd">
 <td>usbd.lib</td>
-<td><p>\Lib\win8\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win7\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\winv6.3\km\<em>&lt;arch&gt;</em></p></td>
+<td><p>\Lib\win8\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win7\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\winv6.3\km\\<em>&lt;arch&gt;</em></p></td>
 <td>Provides helper routines for getting information from the USB driver stack and formatting URBs for requests.</td>
 </tr>
 <tr class="even">
 <td>usbrpm.lib</td>
-<td><p>\Lib\win8\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win7\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\winv6.3\km\<em>&lt;arch&gt;</em></p></td>
+<td><p>\Lib\win8\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win7\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\winv6.3\km\\<em>&lt;arch&gt;</em></p></td>
 <td>Provides functions for an application to perform operations for replacing a Microsoft-provided driver with a third-party RPM driver.</td>
 </tr>
 <tr class="odd">
 <td>usbdex.lib</td>
-<td><p>\Lib\win8\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win7\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\winv6.3\km\<em>&lt;arch&gt;</em></p></td>
+<td><p>\Lib\win8\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win7\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\winv6.3\km\\<em>&lt;arch&gt;</em></p></td>
 <td>Provides helper routines for client drivers to send requests to the underlying USB driver stack. The library gets loaded and statically linked to the client driver module when it is built. A client driver that calls these routines can run on Windows Vista and later versions of Windows.</td>
 </tr>
 <tr class="even">
 <td>winusb.lib</td>
-<td><p>\Lib\win8\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win8\um\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win7\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\win7\um\<em>&lt;arch&gt;</em></p>
-<p>\Lib\winv6.3\km\<em>&lt;arch&gt;</em></p>
-<p>\Lib\winv6.3\um\<em>&lt;arch&gt;</em></p></td>
+<td><p>\Lib\win8\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win8\um\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win7\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\win7\um\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\winv6.3\km\\<em>&lt;arch&gt;</em></p>
+<p>\Lib\winv6.3\um\\<em>&lt;arch&gt;</em></p></td>
 <td>Provides functions for a user-mode client driver or an application to communicate with a USB device that has Winusb.sys loaded as its function driver.</td>
 </tr>
 </tbody>

--- a/windows-driver-docs-pr/usbcon/usb-driver-samples-in-wdk.md
+++ b/windows-driver-docs-pr/usbcon/usb-driver-samples-in-wdk.md
@@ -43,7 +43,7 @@ The topic contains basic information about the USB samples that are available fo
 <td>[USBVIEW](http://go.microsoft.com/fwlink/p/?LinkId=618004)</td>
 <td><p>The USBVIEW sample shows how a user-mode application can enumerate USB host controllers, USB hubs, and attached USB devices and can query information about the devices from the registry and through USB requests to the devices. USBVIEW is based on the Windows Driver Model (WDM).</p>
 <div class="alert">
-<strong>Note</strong>  For USBView tool, get the executable from Windows Driver Kit (WDK) (Tools\<em>&lt;arch&gt;</em> folder).
+<strong>Note</strong>  For USBView tool, get the executable from Windows Driver Kit (WDK) (Tools\\<em>&lt;arch&gt;</em> folder).
 </div>
 <div>
  

--- a/windows-driver-docs-pr/usbcon/usb-registry-settings-for-a-function-controller-driver.md
+++ b/windows-driver-docs-pr/usbcon/usb-registry-settings-for-a-function-controller-driver.md
@@ -56,29 +56,29 @@ This table describes the subkeys that OEMs can modify under this key. More infor
 <tr class="odd">
 <td><strong>Alternates</strong></td>
 <td>This subkey contains additional subkeys that describe an interface that has one or more alternate settings:
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Alternates</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong></p></td>
 </tr>
 <tr class="even">
 <td><strong>Associations</strong></td>
 <td>This subkey defines Interface Association Descriptors (IADs). Each IAD allows multiple interfaces to be grouped into a single function. Each subkey represents a different IAD and OEMs can modify the values for those subkeys.
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Associations</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong></p></td>
 </tr>
 <tr class="odd">
 <td><strong>Default</strong></td>
 <td>This subkey contains default values that are used to describe device-specific settings such as the VID and PID. This is a Microsoft-owned subkey whose values are overridden by those in the parent key:
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong></p></td>
 </tr>
 <tr class="even">
 <td><strong>Configurations</strong></td>
-<td>This subkey contains additional subkeys that contain configuration descriptor values that are used during USB enumeration. For example, the standard test configuration might exist under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Configurations</strong>\<strong>TestConfigClassic</strong>.</td>
+<td>This subkey contains additional subkeys that contain configuration descriptor values that are used during USB enumeration. For example, the standard test configuration might exist under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Configurations</strong>\\<strong>TestConfigClassic</strong>.</td>
 </tr>
 <tr class="odd">
 <td><strong>Configurations\Default</strong></td>
-<td>This subkey contains values for the default configuration. The interfaces in the default configuration are added before the current configuration present when the <strong>IncludeDefaultCfg</strong> value is set under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong> key.</td>
+<td>This subkey contains values for the default configuration. The interfaces in the default configuration are added before the current configuration present when the <strong>IncludeDefaultCfg</strong> value is set under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key.</td>
 </tr>
 <tr class="even">
 <td><strong>Interfaces</strong></td>
-<td>This subkey contains additional subkeys that describe specific interface descriptors. For example, the IP over USB configuration may reside under a subkey named <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Interfaces</strong>\<strong>IpOverUsb</strong>. The name of this subkey for an interface is what determines the hardware ID of the class driver. In the IP over USB example, the _HID of the loaded PDO is <strong>USBFN\IpOverUsb</strong>.</td>
+<td>This subkey contains additional subkeys that describe specific interface descriptors. For example, the IP over USB configuration may reside under a subkey named <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>\\<strong>IpOverUsb</strong>. The name of this subkey for an interface is what determines the hardware ID of the class driver. In the IP over USB example, the _HID of the loaded PDO is <strong>USBFN\IpOverUsb</strong>.</td>
 </tr>
 </tbody>
 </table>
@@ -125,14 +125,14 @@ This table describes the values that OEMs can modify for subkeys under **HKEY\_L
 <td><strong>InterfaceList</strong></td>
 <td>REG_MULTI_SZ</td>
 <td>OEM or Microsoft</td>
-<td><p>Contains a list of interface names that correspond to interface subkeys under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Interfaces</strong>, the IAD associations defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Associations</strong>, and the alternate interfaces defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong>\<strong>Alternates</strong>. Those keys determine the interfaces that are used to describe the composite configuration descriptor.</p>
-<p>If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong> key is set to 1, this list is appended to the Microsoft-owned default interface list to create the complete interface list that the device will use to enumerate.</p></td>
+<td><p>Contains a list of interface names that correspond to interface subkeys under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>, the IAD associations defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong>, and the alternate interfaces defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong>. Those keys determine the interfaces that are used to describe the composite configuration descriptor.</p>
+<p>If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, this list is appended to the Microsoft-owned default interface list to create the complete interface list that the device will use to enumerate.</p></td>
 </tr>
 <tr class="even">
 <td><strong>MSOSCompatIdDescriptor</strong></td>
 <td>REG_BINARY</td>
 <td>OEM or Microsoft</td>
-<td><p>Optional. Defines an Extended Compat ID OS Feature Descriptor for the configuration. If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\<strong>USBFN</strong> key is set to 1, the functions in this descriptor are appended to the functions and interfaces in the default configuration.</p></td>
+<td><p>Optional. Defines an Extended Compat ID OS Feature Descriptor for the configuration. If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, the functions in this descriptor are appended to the functions and interfaces in the default configuration.</p></td>
 </tr>
 </tbody>
 </table>

--- a/windows-driver-docs-pr/wdf/using-the-framework-s-event-logger.md
+++ b/windows-driver-docs-pr/wdf/using-the-framework-s-event-logger.md
@@ -47,7 +47,7 @@ You can use WDF debugger extensions to view and save the WDF log during interact
     Because .tmf files are version specific, you must specify a .tmf file that corresponds to the version of the framework's runtime library that is currently running. For example, if KMDF version 1.9 is running on the host machine:
 
     ```
-    !wdftmffile c:\WinDDK\\<version>\tools\tracing\x86\wdf01009.tmf
+    !wdftmffile c:\WinDDK\<version>\tools\tracing\x86\wdf01009.tmf
     ```
 
     You can also set the search path by setting the TRACE\_FORMAT\_SEARCH\_PATH environment variable. The [**!wdftmffile**](https://msdn.microsoft.com/library/windows/hardware/ff566128) command takes precedence over the search path that is set by the environment variable.


### PR DESCRIPTION
Fix formatting with `\<`.

(ex) https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags-details

![image](https://user-images.githubusercontent.com/39562/30865470-aec8e870-a311-11e7-80ce-b43e136dea50.png)
