### PR TITLE
Adding note about running from driver store.

### DIFF
--- a/windows-driver-docs-pr/install/driver-store.md
+++ b/windows-driver-docs-pr/install/driver-store.md
@@ -16,6 +16,8 @@ Starting with Windows Vista, the driver store is a trusted collection of inbox a
 
 When a driver package is copied to the driver store, all of its files are copied. This includes the [INF file](overview-of-inf-files.md) and all files that are referenced by the INF file. All files that are in the driver package are considered critical to the device installation. The INF file must reference all of the required files for device installation so that they are present in the driver store. If the INF file references a file that is not included in the driver package, the driver package is not copied to the store.
 
+Once files are copied to the driver store, they should not be removed or modified in any way. 
+
 The process of copying a driver package to the driver store is called *staging*. A driver package must be *staged* to the driver store before the package can be used to install any devices. As a result, driver staging and device installation are separate operations.
 
 A driver package is staged to the driver store by being verified and validated:


### PR DESCRIPTION
Once files are copied to the driver store, they should not be removed or modified in any way.