### PR TITLE
Minor readability improvement on `Debugging Environments`

### DIFF
--- a/windows-driver-docs-pr/debugger/debuggers-in-the-debugging-tools-for-windows-package.md
+++ b/windows-driver-docs-pr/debugger/debuggers-in-the-debugging-tools-for-windows-package.md
@@ -77,7 +77,9 @@ There is a variation of the KD debugger named NTKD. It is identical to KD in eve
 
 ### <span id="CDB"></span><span id="cdb"></span>CDB
 
-Microsoft Console Debugger (CDB) is a character-based console program that enables low-level analysis of Windows user-mode memory and constructs. CDB is extremely powerful for debugging a program that is currently running or has recently crashed (live analysis), yet simple to set up. It can be used to investigate the behavior of a working application. In the case of a failing application, CDB can be used to obtain a stack trace or to look at the guilty parameters. It works well across a network (using a remote access server), as it is character-based.
+Microsoft Console Debugger (CDB) is a character-based console program that enables low-level analysis of Windows user-mode memory and constructs. The name *Console Debugger* is used to indicate the fact that CDB is classified as a console application; it does not imply that the target application must be a console application. In fact, CDB is fully capable of debugging both console applications and graphical Windows programs.
+
+CDB is extremely powerful for debugging a program that is currently running or has recently crashed (live analysis), yet simple to set up. It can be used to investigate the behavior of a working application. In the case of a failing application, CDB can be used to obtain a stack trace or to look at the guilty parameters. It works well across a network (using a remote access server), as it is character-based.
 
 With CDB, you can display and execute program code, set breakpoints, and examine and change values in memory. CDB can analyze binary code by disassembling it and displaying assembly instructions. It can also analyze source code directly.
 
@@ -88,8 +90,6 @@ If the target application is itself a console application, the target will share
 ### <span id="NTSD"></span><span id="ntsd"></span>NTSD
 
 There is a variation of the CDB debugger named Microsoft NT Symbolic Debugger (NTSD). It is identical to CDB in every way, except that it spawns a new text window when it is started, whereas CDB inherits the Command Prompt window from which it was invoked.
-
-Like CDB, NTSD is fully capable of debugging both console applications and graphical Windows programs. (The name *Console Debugger* is used to indicate the fact that CDB is classified as a console application; it does not imply that the target application must be a console application.)
 
 Since the **start** command can also be used to spawn a new console window, the following two constructions will give the same results:
 


### PR DESCRIPTION
Moved a couple of sentences from the `NTSD` section to the `CDB` section to improve readability.