### PR TITLE
Update -fileobj.md

### DIFF
--- a/windows-driver-docs-pr/debugger/-fileobj.md
+++ b/windows-driver-docs-pr/debugger/-fileobj.md
@@ -29,7 +29,7 @@ The **!fileobj** extension displays detailed information about a FILE\_OBJECT st
 
 
 <span id="_______FileObject______"></span><span id="_______fileobject______"></span><span id="_______FILEOBJECT______"></span> *FileObject*   
-Specifies the address of a FILE\_OBJECT structure.
+Specifies the address of a [FILE\_OBJECT](https://msdn.microsoft.com/library/windows/hardware/ff545834.aspx) structure.
 
 ### <span id="DLL"></span><span id="dll"></span>DLL
 


### PR DESCRIPTION
Are there any plans to move documentation such as for the FILE_OBJECT structure from MSDN to docs.microsoft.com?
I didn't find anything on docs, so I created a link pointing to MSDN.