### PR TITLE
Adds link to the Debugging Tools for Windows page

### DIFF
--- a/windows-driver-docs-pr/debugger/using-srcsrv.md
+++ b/windows-driver-docs-pr/debugger/using-srcsrv.md
@@ -13,7 +13,7 @@ ms.technology: windows-devices
 # Using SrcSrv
 
 
-To use [SrcSrv](srcsrv.md) with WinDbg, KD, NTSD, or CDB, verify that you have installed a recent version of the Debugging Tools for Windows package (version 6.3 or later). Then, include the text `srv*` in the source path, separated by semicolons from any directories that are also in the source path.
+To use [SrcSrv](srcsrv.md) with WinDbg, KD, NTSD, or CDB, verify that you have installed a recent version of the [Debugging Tools for Windows](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/) package (version 6.3 or later). Then, include the text `srv*` in the source path, separated by semicolons from any directories that are also in the source path.
 
 For example:
 


### PR DESCRIPTION
The linked page contains download links. I'm not sure if I should have used an absolute URL or relative URL (just up the directory: `..`)