### PR TITLE
Translates into korean.

### DIFF
--- a/windows-driver-docs-pr/kernel/previousmode.md
+++ b/windows-driver-docs-pr/kernel/previousmode.md
@@ -13,27 +13,26 @@ ms.technology: windows-devices
 
 # PreviousMode
 
+유저모드 애플리케이션이 **Nt** 또는 **Zw** 버전의 네이티브 시스템 서비스 루틴을 호출하면 시스템 콜 매커니즘이 호출 스레드를 커널모드로 트랩합니다. 매개 변수 값이 유저모드에서 시작되었음을 알리기 위해 호출자 [thread object](introduction-to-thread-objects.md)의 **PreviousMode** 필드를 **UserMode** 로 설정합니다. 네이티브 시스템 서비스 루틴은 매개변수가 유저모드로부터 왔는지 확인하기 위해 호출 스레드의 **PreviousMode** 필드를 확인합니다.  
 
-When a user-mode application calls the **Nt** or **Zw** version of a native system services routine, the system call mechanism traps the calling thread to kernel mode. To indicate that the parameter values originated in user mode, the trap handler for the system call sets the **PreviousMode** field in the [thread object](introduction-to-thread-objects.md) of the caller to **UserMode**. The native system services routine checks the **PreviousMode** field of the calling thread to determine whether the parameters are from a user-mode source.
+만일 커널모드 드라이버가 네이티브 시스템 서비스 루틴을 호출하고 매개 변수를 커널모드 루틴에 전달하는 경우 현재 스레드 오브젝트의 **PreviousMode** 필드는 반드시 **KernelMode** 이어야 합니다. 
 
-If a kernel-mode driver calls a native system services routine and passes parameter values to the routine that are from a kernel-mode source, the driver must make sure that the **PreviousMode** field in the current thread object is set to **KernelMode**.
+커널모드 드라이버는 임의의 스레드 컨텍스트에서 실행 될 수 있고, **PreviousMode** 필드가 **UserMode**로 설정될 수 있습니다. 이 경우 커널모드 드라이버는 **Zw** 버전의 네이티브 서비스 루틴을 호출하여 매개 변수 값이 신뢰할 수 있는, 커널모드 호출임을 알릴 수 있습니다. **Zw** 호출은 현재 스레드 객체의 **PreviousMode** 값을 겹쳐 쓰는 간단한 래퍼함수로 이동합니다. 래퍼함수는 **PreviousMode** 를 **KernelMode**로 설정하고 **Nt** 버전의 루틴을 호출합니다. **Nt** 버전 루틴이 리턴하면 래퍼함수는 스레드 오브젝트의 원래 **PreviousMode** 값으로 복원하고 반환합니다.  
 
-A kernel-mode driver can run in the context of an arbitrary thread, and the **PreviousMode** field of this thread might be set to **UserMode**. In this situation, a kernel-mode driver can call the **Zw** version of a native system services routine to inform the routine that the parameter values are from a trusted, kernel-mode source. The **Zw** call goes to a thin wrapper function that overrides the **PreviousMode** value in the current thread object. The wrapper function sets **PreviousMode** to **KernelMode** and calls the **Nt** version of the routine. On return from the **Nt** version of the routine, the wrapper function restores the original **PreviousMode** value of the thread object and returns.
+커널모드 드라이버는 **Nt** 버전의 네이티브 시스템 서비스 루틴을 직접 호출할 수 있습니다. 커널모드 드라이버가 유저모드나 커널모드에서 시작될 수 있는 I/O 요청을 처리할때, 드라이버는 **Nt** 버전의 루틴을 호출하여 루틴이 실행되는 동안 현재 스레드의 **PreviousMode** 값이 변경되지 않도록 할 수 있습니다. **Nt*Xxx*** 루틴은 호출 스레드의 **PreviousMode** 값을 통해 매개변수가 유저모드에서 왔는지 커널모드 콤포넌트에서 왔는지 판단하고, 적절하게 처리합니다.  
 
-A kernel-mode driver can directly call the **Nt** version of a native system services routine. When a kernel-mode driver processes an I/O request that can originate either in user mode or in kernel mode, the driver can call the **Nt** version of the routine so that the **PreviousMode** value of the current thread remains unaltered during the call. The **Nt*Xxx*** routine checks the calling thread's **PreviousMode** value to determine whether the parameter values are from a user-mode application or a kernel-mode component, and treats them accordingly.
+커널모드 드라이버가 **Nt*Xxx*** 루틴을 호출하고, 현재 스레드 오브젝트의 **PreviousMode** 값이 매개변수의 출처가 유저모드인지, 커널모드인지를 정확하게 가리키지 못한다면 오류가 발생 할 수 있습니다. 
 
-An error can occur if a kernel-mode driver calls an **Nt*Xxx*** routine and the **PreviousMode** value in the current thread object does not accurately indicate whether the parameter values are from a user-mode or a kernel-mode source.
+예를 들어, 커널모드 드라이버가 임의의 스레드 컨텍스트에서 실행중이고, **PreviousMode** 값이 **UserMode** 인 경우를 가정합니다. 만일 드라이버가 커널모드 파일 핸들을 [**NtClose**](https://msdn.microsoft.com/library/windows/hardware/ff566417)루틴에 전달한 경우 이 루틴은 **PreviousMode** 값을 확인하고, 핸들이 유저모드 핸들이어야 한다고 결정합니다. **NtClose**가 유저모드 핸들테이블에서 핸들을 찾을 수 없으므로 STATUS\_INVALID\_HANDLE 에러코드를 리턴합니다. 반면에 드라이버는 절대 핸들을 닫을 수 없기 때문에 핸들 누수 상황을 만들게 됩니다. 
 
-For example, assume that a kernel-mode driver is running in the context of an arbitrary thread, and that the **PreviousMode** value for this thread is set to **UserMode**. If the driver passes a kernel-mode file handle to the [**NtClose**](https://msdn.microsoft.com/library/windows/hardware/ff566417) routine, this routine checks the **PreviousMode** value and decides that the handle must be a user-mode handle. When **NtClose** does not find the handle in the user-mode handle table, it returns the STATUS\_INVALID\_HANDLE error code. Meanwhile, the driver leaks the kernel-mode handle, which was never closed.
+다른 예로, 만일 **Nt*Xxx*** 루틴의 매개변수에 입력 또는 출력 버퍼가 포함되어있고, **PreviousMode** = **UserMode** 인 경우 루틴은 버퍼를 검증하기 위해 [**ProbeForRead**](https://msdn.microsoft.com/library/windows/hardware/ff559876) 또는 [**ProbeForWrite**](https://msdn.microsoft.com/library/windows/hardware/ff559879) 루틴을 호출합니다. 만일 버퍼가 유저모드 메모리가 아니라 시스템 메모리에 할당되어있는 경우 **ProbeFor*Xxx*** 루틴은 예외를 발생시키고, **Nt*Xxx*** 루틴은 STATUS\_ACCESS\_VIOLATION 에러코드를 리턴하게 됩니다. 
 
-For another example, if the parameters for an **Nt*Xxx*** routine include an input or output buffer, and if **PreviousMode** = **UserMode**, the routine calls the [**ProbeForRead**](https://msdn.microsoft.com/library/windows/hardware/ff559876) or [**ProbeForWrite**](https://msdn.microsoft.com/library/windows/hardware/ff559879) routine to validate the buffer. If the buffer was allocated in system memory instead of in user-mode memory, the **ProbeFor*Xxx*** routine raises an exception, and the **Nt*Xxx*** routine returns the STATUS\_ACCESS\_VIOLATION error code.
-
-If it is necessary, a driver can call the [**ExGetPreviousMode**](https://msdn.microsoft.com/library/windows/hardware/ff545288) routine to get the **PreviousMode** value from the current thread object. Or, the driver can read the **RequestorMode** field from the [**IRP**](https://msdn.microsoft.com/library/windows/hardware/ff550694) structure that describes the requested I/O operation. The **RequestorMode** field contains a copy of the **PreviousMode** value from the thread that requested the operation.
-
- 
+필요한 경우 드라이버는 [**ExGetPreviousMode**](https://msdn.microsoft.com/library/windows/hardware/ff545288) 루틴을 호출해서 현재 스레드 오브젝트의 **PreviousMode** 값을 가져올 수 있습니다. 또는 요청된 I/O 작업 정보를 담고있는 [**IRP**](https://msdn.microsoft.com/library/windows/hardware/ff550694) 구조체의 **RequestorMode** 필드를 읽을 수 있습니다. **RequestorMode** 필드는 작업을 요청한 스레드의 **PreviousMode** 값의 사본을 포함합니다. 
 
  
 
 
+--------------------
+[Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20%5Bkernel\kernel%5D:%20PreviousMode%20%20RELEASE:%20%286/14/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 
 

--- a/windows-driver-docs-pr/kernel/using-nt-and-zw-versions-of-the-native-system-services-routines.md
+++ b/windows-driver-docs-pr/kernel/using-nt-and-zw-versions-of-the-native-system-services-routines.md
@@ -13,20 +13,19 @@ ms.technology: windows-devices
 
 # Using Nt and Zw Versions of the Native System Services Routines
 
+Windows 의 네이티브 서비스 API 는 커널모드에서 동작하는 루틴들의 집합으로 이루어져있습니다. 이 루틴들의 이름은 **Nt** 또는 **Zw** 로 시작합니다. 커널모드 드라이버들은 이 루틴들을 직접 호출할 수 있으며, 유저모드 어플리케이션들은 시스템 콜을 통해서 이 루틴들을 호출할 수 있습니다.  
 
-The Windows native operating system services API is implemented as a set of routines that run in kernel mode. These routines have names that begin with the prefix **Nt** or **Zw**. Kernel-mode drivers can call these routines directly. User-mode applications can access these routines by using system calls.
+몇몇 예외사항이 있긴 하지만 각각의 네이티브 시스템 서비스 루틴들은 비슷한 이름의 접두어만 다른 두가지 버전이 있습니다. 예를 들어 [NtCreateFile](http://go.microsoft.com/fwlink/p/?linkid=157250) 와 [**ZwCreateFile**](https://msdn.microsoft.com/library/windows/hardware/ff566424) 호출은 비슷한 작업을 수행하지만 사실은 동일한 커널모드 시스템 루틴에 의해서 처리됩니다. 유저모드에서의 **Nt** 와 **Zw** 버전 루틴은 동일하지만 커널모드에서의 **Nt** 와 **Zw** 버전 루틴들은 호출자가 전달한 파라미터 값을 다루는 방식이 다릅니다. 
 
-With a few exceptions, each native system services routine has two slightly different versions that have similar names but different prefixes. For example, calls to [NtCreateFile](http://go.microsoft.com/fwlink/p/?linkid=157250) and [**ZwCreateFile**](https://msdn.microsoft.com/library/windows/hardware/ff566424) perform similar operations and are, in fact, serviced by the same kernel-mode system routine. For system calls from user mode, the **Nt** and **Zw** versions of a routine behave identically. For calls from a kernel-mode driver, the **Nt** and **Zw** versions of a routine differ in how they handle the parameter values that the caller passes to the routine.
+커널모드 드라이버는 전달되는 매개변수가 신뢰 할 수 있는 커널모드에서 전달된 것임을 알리기 위해 **Zw** 버전의 네이티브 서비스 루틴을 호출합니다. 이 경우 루틴은 매개변수를 검증하지 않고 안전하게 사용할 수 있다고 가정합니다. 그러나 매개변수가 유저모드 또는 커널모드 중 하나일 경우라면 드라이버는 **Nt** 버전의 루틴을 호출하는데 이는 루틴을 호출한 스레드의 기록을 기반으로 매개변수가 유저모드에서 전달되었는지 커널모드에서 전달되었는지를 구별합니다. 커널모드 매개변수와 유저모드 매개변수를 구분하는 방법에 대한 자세한 내용은 [**PreviousMode**](previousmode.md)를 참조하십시오.
 
-A kernel-mode driver calls the **Zw** version of a native system services routine to inform the routine that the parameters come from a trusted, kernel-mode source. In this case, the routine assumes that it can safely use the parameters without first validating them. However, if the parameters might be from either a user-mode source or a kernel-mode source, the driver instead calls the **Nt** version of the routine, which determines, based on the history of the calling thread, whether the parameters originated in user mode or kernel mode. For more information about how the routine distinguishes user-mode parameters from kernel-mode parameters, see [**PreviousMode**](previousmode.md).
+유저모드 애플리케이션이 **Nt** 또는 **Zw** 버전의 네이티브 시스템 서비스 루틴을 호출하면 루틴은 항상 매개변수는 신뢰할 수 없는 유저모드에서 전달된 것으로 간주하고 매개변수를 사용하기 전에 철저히 검증합니다. 특히 루틴은 호출자가 제공한 버퍼를 검사하여 버퍼가 유효한 유저모드 메모리에 존재하고 있으며 올바르게 정렬되어있는지 확인합니다.
 
-When a user-mode application calls the **Nt** or **Zw** version of a native system services routine, the routine always treats the parameters that it receives as values that come from a user-mode source that is not trusted. The routine thoroughly validates the parameter values before it uses the parameters. In particular, the routine probes any caller-supplied buffers to verify that the buffers are located in valid user-mode memory and are aligned properly.
+네이티브 시스템 서비스 루틴은 매개변수에 대한 추가적인 가정을 합니다. 만일 커널모드 드라이버가 할당한 버퍼의 포인터를 매개변수로 받은 경우 버퍼는 유저모드 메모리가 아니라 시스템 메모리에 할당되어있다고 가정합니다. 만일 유저모드 애플리케이션에서 열어둔 핸들을 받으면 루틴은 커널모드 핸들테이블이 아니라 유저모드 핸들테이블에서 핸들을 찾습니다.  
 
-Native system services routines make additional assumptions about the parameters that they receive. If a routine receives a pointer to a buffer that was allocated by a kernel-mode driver, the routine assumes that the buffer was allocated in system memory, not in user-mode memory. If the routine receives a handle that was opened by a user-mode application, the routine looks for the handle in the user-mode handle table, not in the kernel-mode handle table.
+몇 가지 예에서 매개변수 값의 의미는 사용자 모드 및 커널모드에서의 호출간에 더 크게 다릅니다. 예를 들어 [**ZwNotifyChangeKey**](https://msdn.microsoft.com/library/windows/hardware/ff566488) 루틴 (또는 해당 **NtNotifyChangeKey** 버전)에는 입력 매개변수 쌍이 있습니다. *ApcRoutine* 과 *ApcContext* 는 유저모드에서의 호출인지 커널모드에서의 호출인지에 따라 의미가 다릅니다. 유저모드 호출인 경우 *ApcRoutine*은 APC 루틴을 가리키고, *ApcContext*는 APC 루틴을 호출할 때 운영체제가 제공하는 컨텍스트 값을 가리킵니다. 커널모드 호출인 경우 *ApcRoutine* 은 [**WORK\_QUEUE\_ITEM**](https://msdn.microsoft.com/library/windows/hardware/ff557304) 구조체를 가리키고 *ApcContext* 는 **WORK\_QUEUE\_ITEM** 구조체에 의해서 기술되는 워크 큐 아이템의 타입을 가리킵니다. 
 
-In a few instances, the meaning of a parameter value differs more significantly between calls from user mode and from kernel mode. For example, the [**ZwNotifyChangeKey**](https://msdn.microsoft.com/library/windows/hardware/ff566488) routine (or its **NtNotifyChangeKey** counterpart) has a pair of input parameters, *ApcRoutine* and *ApcContext*, that mean different things, depending on whether the parameters are from a user-mode or kernel-mode source. For a call from user mode, *ApcRoutine* points to an APC routine and *ApcContext* points to a context value that the operating system supplies when it calls the APC routine. For a call from kernel mode, *ApcRoutine* points to a [**WORK\_QUEUE\_ITEM**](https://msdn.microsoft.com/library/windows/hardware/ff557304) structure, and *ApcContext* specifies the type of work queue item that is described by the **WORK\_QUEUE\_ITEM** structure.
-
-This section includes the following topics:
+이 섹션은 다음의 주제가 포함되어있습니다:
 
 [**PreviousMode**](previousmode.md)
 
@@ -43,5 +42,7 @@ This section includes the following topics:
  
 
 
+--------------------
+[Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20%5Bkernel\kernel%5D:%20Using%20Nt%20and%20Zw%20Versions%20of%20the%20Native%20System%20Services%20Routines%20%20RELEASE:%20%286/14/2017%29&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/default.aspx. "Send comments about this topic to Microsoft")
 
 


### PR DESCRIPTION
This PR translates two docs into Korean.

- kernel\previousmode.md
- kernel\using-nt-and-zw-versions-of-the-native-system-services-routines.md
