### PR TITLE
Clarify what "output" variable stands for

### DIFF
--- a/windows-driver-docs-pr/debugger/native-objects-in-javascript-extensions.md
+++ b/windows-driver-docs-pr/debugger/native-objects-in-javascript-extensions.md
@@ -30,7 +30,7 @@ For example the host.namespace.Debugger.Utility.Control.ExecuteCommand object ca
 
 ```
 var ctl = host.namespace.Debugger.Utility.Control;   
-var output = ctl.ExecuteCommand("u");
+var outputLines = ctl.ExecuteCommand("u");
 ```
 
 This topic describes how to work with common objects and provides reference information on their attributes and behaviors.


### PR DESCRIPTION
In existing example: 
var output = ctl.ExecuteCommand("u");
It's not clear what type "output" represents. Is it a string blob? Is it some internal log type?
It turns out that it's actually an array of string lines. Changing "output" variable name to "outputLines" could make it more clear that it's an array.
Proposed change:
var outputLines = ctl.ExecuteCommand("u");