### PR TITLE
Grammer: possessive form

### DIFF
--- a/windows-driver-docs-pr/mobilebroadband/cosa-overview.md
+++ b/windows-driver-docs-pr/mobilebroadband/cosa-overview.md
@@ -11,7 +11,7 @@ ms.technology: windows-devices
 
 # COSA overview
 
-COSA, or Country and Operator Settings Asset, is the new format Mobile Operators (MOs) used in Windows 10, version 1703 and later to provision Windows devices for mobile broadband. The existing APN database (apndatabase.xml) from Windows 8, Windows 8.1, and versions of Windows 10 before Windows 10, version 1703 has been converted to COSA, which is ingestible by the new provisioning framework. Note that these previous versions of Windows will continue to use the older APN database for provisioning desktop devices.
+COSA, or Country and Operator Settings Asset, is the new format that Mobile Operators (MOs) use in Windows 10, version 1703 and later to provision Windows devices for mobile broadband. The existing APN database (apndatabase.xml) from Windows 8, Windows 8.1, and versions of Windows 10 before 1703 has been converted to COSA, which is ingestible by the new provisioning framework. Note that these previous versions of Windows will continue to use the older APN database for provisioning desktop devices.
 
 For more information about the older APN database, see [APN database overview](apn-database-overview.md).
 

--- a/windows-driver-docs-pr/mobilebroadband/cosa-overview.md
+++ b/windows-driver-docs-pr/mobilebroadband/cosa-overview.md
@@ -11,7 +11,7 @@ ms.technology: windows-devices
 
 # COSA overview
 
-COSA, or Country and Operator Settings Asset, is the new format Mobile Operators (MOs) use in Windows 10, version 1703 and later to provision Windows devices for mobile broadband. The existing APN database (apndatabase.xml) from Windows 8, Windows 8.1, and versions of Windows 10 before Windows 10, version 1703 has been converted to COSA, which is ingestible by the new provisioning framework. Note that these previous versions of Windows will continue to use the older APN database for provisioning desktop devices.
+COSA, or Country and Operator Settings Asset, is the new format Mobile Operators (MOs) used in Windows 10, version 1703 and later to provision Windows devices for mobile broadband. The existing APN database (apndatabase.xml) from Windows 8, Windows 8.1, and versions of Windows 10 before Windows 10, version 1703 has been converted to COSA, which is ingestible by the new provisioning framework. Note that these previous versions of Windows will continue to use the older APN database for provisioning desktop devices.
 
 For more information about the older APN database, see [APN database overview](apn-database-overview.md).
 


### PR DESCRIPTION
Updated the sentence: "COSA[…]is the new format Mobile Operators (MOs) 'use' in Windows 10, version 1703 and later to provision Windows devices for mobile broadband." Changed the "use" to "used".

This is not a past tense. It is a possessive form. Something is USING Windows 10 to accomplish a task, in this case to provision devices for mobile broadband.

Let's give a couple examples. "This car is used by Emily for her daily commutes". This sentence is still in present tense. To say "This car is use by Emily for her daily commutes" would be grammeritacally incorrect.

Another example: "Visual Studio 2017 is used for developing UWP apps". This is a present tense, but, again, note the "used" is correct here. If it were past tense, it would be something like this: "Visual Studio 6.0 was used for C++ and VB6 development in the 90s". Note that the ver "to be" is either "is" or "was", depending on whether the sentence is past or present and the verb "to use" is alwasy written as "used" in both cases.