### PR TITLE
Fixing a typo.

### DIFF
--- a/windows-driver-docs-pr/debugger/using-a-manifest-file-with-symchk.md
+++ b/windows-driver-docs-pr/debugger/using-a-manifest-file-with-symchk.md
@@ -21,7 +21,7 @@ In some cases, you might need to retrieve symbols for files that are on an isola
 
 2.  Move the manifest file to a network that has a symbol store.
 
-3.  Run SymChk with **/im** parameter to retrieve symbols for the files described int the manifest file.
+3.  Run SymChk with the **/im** parameter to retrieve symbols for the files described in the manifest file.
 
 4.  Move the symbol files back to the isolated computer.
 


### PR DESCRIPTION
Fixing a typo and adding "the" to the sentence to make it consistent with Step #1.