### PR TITLE
Update Driver Verifier check locations

### DIFF
--- a/windows-driver-docs-pr/devtest/automatic-checks.md
+++ b/windows-driver-docs-pr/devtest/automatic-checks.md
@@ -82,21 +82,6 @@ In particular, Driver Verifier looks for:
 
 Problems such as these can potentially cause system bug checks to be issued a while after the driver unloads, and the cause of these bug checks can be hard to determine. When Driver Verifier is active, such violations will result in bug check 0xC7 being issued immediately after the driver is unloaded. See [**Bug Check 0xC7**](https://msdn.microsoft.com/library/windows/hardware/ff560198) (TIMER\_OR\_DPC\_INVALID) for a list of the bug check parameters.
 
-### <span id="Monitoring__Driver_Dispatch_Routines"></span><span id="monitoring__driver_dispatch_routines"></span><span id="MONITORING__DRIVER_DISPATCH_ROUTINES"></span>Monitoring Driver Dispatch Routines
-
-In Windows Vista, Driver Verifier also monitors the selected driver for the following forbidden actions:
-
--   Calling [**IoCallDriver**](https://msdn.microsoft.com/library/windows/hardware/ff548336) with interrupts disabled.
-
--   Calling **IoCallDriver** at IRQL greater than DISPATCH\_LEVEL.
-
--   Returning from a driver dispatch routine with interrupts disabled.
-
--   Returning from a driver dispatch routine with a changed IRQL.
-
--   Returning from a driver dispatch routine with APCs disabled. In this case, the driver might have called [**KeEnterCriticalRegion**](https://msdn.microsoft.com/library/windows/hardware/ff552021) more times than [**KeLeaveCriticalRegion**](https://msdn.microsoft.com/library/windows/hardware/ff552964), which is the primary cause for [**Bug Check 0x20**](https://msdn.microsoft.com/library/windows/hardware/ff557421) (KERNEL\_APC\_PENDING\_DURING\_EXIT) and [**Bug Check 0x1**](https://msdn.microsoft.com/library/windows/hardware/ff557419) (APC\_INDEX\_MISMATCH).
-
-If Driver Verifier is not active, these violations might not cause the system to stop responding immediately in all cases. Driver Verifier monitors the driver's behavior and issues bug check 0xC4 if any of these violations occur. See [**Bug Check 0xC4**](https://msdn.microsoft.com/library/windows/hardware/ff560187) (DRIVER\_VERIFIER\_DETECTED\_VIOLATION) for a list of the bug check parameters.
 
 ### <span id="Monitoring__Memory_Descriptor_List__MDL__Usage"></span><span id="monitoring__memory_descriptor_list__mdl__usage"></span><span id="MONITORING__MEMORY_DESCRIPTOR_LIST__MDL__USAGE"></span>Monitoring Memory Descriptor List (MDL) Usage
 

--- a/windows-driver-docs-pr/devtest/i-o-verification.md
+++ b/windows-driver-docs-pr/devtest/i-o-verification.md
@@ -75,6 +75,16 @@ Starting in Window Vista, the I/O Verification option checks for the following d
 
 -   Calling [**IoReleaseRemoveLock**](https://msdn.microsoft.com/library/windows/hardware/ff549560) or [**IoReleaseRemoveLockAndWait**](https://msdn.microsoft.com/library/windows/hardware/ff549567) with a tag parameter that differs from the tag parameter used in the corresponding [**IoAcquireRemoveLock**](https://msdn.microsoft.com/library/windows/hardware/ff548204) call.
 
+-   Calling [**IoCallDriver**](https://msdn.microsoft.com/library/windows/hardware/ff548336) with interrupts disabled.
+
+-   Calling [**IoCallDriver**](https://msdn.microsoft.com/library/windows/hardware/ff548336) at IRQL greater than DISPATCH\_LEVEL.
+
+-   Returning from a driver dispatch routine with interrupts disabled.
+
+-   Returning from a driver dispatch routine with a changed IRQL.
+
+-   Returning from a driver dispatch routine with APCs disabled. In this case, the driver might have called [**KeEnterCriticalRegion**](https://msdn.microsoft.com/library/windows/hardware/ff552021) more times than [**KeLeaveCriticalRegion**](https://msdn.microsoft.com/library/windows/hardware/ff552964), which is the primary cause for [**Bug Check 0x20**](https://msdn.microsoft.com/library/windows/hardware/ff557421) (KERNEL\_APC\_PENDING\_DURING\_EXIT) and [**Bug Check 0x1**](https://msdn.microsoft.com/library/windows/hardware/ff557419) (APC\_INDEX\_MISMATCH).
+
 Starting in Windows 7, the I/O Verification option checks for the following driver errors:
 
 -   Attempts to free IRPs by calling [**ExFreePool**](https://msdn.microsoft.com/library/windows/hardware/ff544590). IRPs must be freed with [**IoFreeIrp**](https://msdn.microsoft.com/library/windows/hardware/ff549113).


### PR DESCRIPTION
Updated docs to reflect that several of the checks listed under Automatic Checks are actually under the IO Verification option.  They have been under IO Verification, not Automatic Checks, since at least as far back as 2007 and at least as far back as Windows Vista.  This has been verified against OS source code implementation.