### PR TITLE
Allow for Platform defined NetworkDirect Transport Selection

### DIFF
--- a/windows-driver-docs-pr/network/inf-requirements-for-ndkpi.md
+++ b/windows-driver-docs-pr/network/inf-requirements-for-ndkpi.md
@@ -20,19 +20,38 @@ The INF file for a miniport driver that supports Network Direct kernel (NDK) mus
     HKR, Ndi\Interfaces, UpperRange, 0, "ndis5"
     ```
 
--   The INF file must specify the **\*NetworkDirect** keyword value as follows. Once the driver is installed, administrators can update the **\*NetworkDirect** keyword value in the **Advanced** property page for the adapter. For more information about advanced properties, see [Specifying Configuration Parameters for the Advanced Properties Page](specifying-configuration-parameters-for-the-advanced-properties-page.md).
+-   The INF file must specify the **\*NetworkDirect** keyword value as follows. Once the driver is installed, administrators can update the **\*NetworkDirect** keyword value in the **Advanced** property page for the adapter. 
 
-    **Note**   The miniport driver is automatically restarted after a change is made in the **Advanced** property page for the adapter.
+    **Note**   The miniport driver is automatically restarted after a change is made in the **Advanced** property page for the adapter.
 
-     
+     
 
     ``` syntax
-    HKR, Ndi\Params\*NetworkDirect,  ParamDesc,  0, "NetworkDirect Functionality"
-    HKR, Ndi\Params\*NetworkDirect,  Type,       0, "enum"
-    HKR, Ndi\Params\*NetworkDirect,  Default,    0, "1"
-    HKR, Ndi\Params\*NetworkDirect\enum,   "0",  0, "Disabled"
-    HKR, Ndi\Params\*NetworkDirect\enum,   "1",  0, "Enabled"
+    HKR, Ndi\Params\*NetworkDirect,        ParamDesc,  0, "NetworkDirect Functionality"
+    HKR, Ndi\Params\*NetworkDirect,        Type,       0, "enum"
+    HKR, Ndi\Params\*NetworkDirect,        Default,    0, "1"
+    HKR, Ndi\Params\*NetworkDirect\enum,   "0",        0, "Disabled"
+    HKR, Ndi\Params\*NetworkDirect\enum,   "1",        0, "Enabled"
     ```
+
+
+-   The INF file must specify the **\*NetworkDirectTechnology** keyword value as follows. Once the driver is installed, administrators can update the **\*NetworkDirectTechnology** keyword value in the **Advanced** property page for the adapter. The enumerations are mutually exclusive, meaning  the selection of a NetworkDirectTechnology value excludes all others.  This allows for the Platform to define strict  device behavior.  For devices where multiple transports can be supported concurrently, the **Undefined** allows for device specific behavior, such as retry/fallback to multiple transports.
+
+    **Note**   The miniport driver is automatically restarted after a change is made in the **Advanced** property page for the adapter.
+
+    ```
+    HKR, Ndi\Params\*NetworkDirectTechnology,        ParamDesc,  0,  "NetworkDirect Technology"
+    HKR, Ndi\Params\*NetworkDirectTechnology,        Default,    0,  "1"
+    HKR, Ndi\Params\*NetworkDirectTechnology,        Type,       0,  "enum"
+    HKR, Ndi\Params\*NetworkDirectTechnology\enum,   1,          0,  "Undefined"
+    HKR, Ndi\Params\*NetworkDirectTechnology\enum,   2,          0,  "iWARP"
+    HKR, Ndi\Params\*NetworkDirectTechnology\enum,   3,          0,  "InfiniBand"
+    HKR, Ndi\Params\*NetworkDirectTechnology\enum,   4,          0,  "RoCE"
+    HKR, Ndi\Params\*NetworkDirectTechnology\enum,   5,          0,  "RoCEv2"
+    HKR, Ndi\Params\*NetworkDirectTechnology,        Optional,   0,  "1"
+    ```
+
+    For more information about advanced properties, see [Specifying Configuration Parameters for the Advanced Properties Page](specifying-configuration-parameters-for-the-advanced-properties-page.md).
 
     For more information about using standardized INF keywords, see [Standardized INF Keywords for Network Devices](standardized-inf-keywords-for-network-devices.md).
 
@@ -41,12 +60,4 @@ The INF file for a miniport driver that supports Network Direct kernel (NDK) mus
 
 [Network Direct Kernel Provider Interface (NDKPI)](network-direct-kernel-programming-interface--ndkpi-.md)
 
- 
-
- 
-
-
-
-
-
-
+ 


### PR DESCRIPTION
This PR defined a new Standardized RegKey, *NetworkDirectTechnology.  It allows for Set-NetAdapterAdvancedProperties to select the RDMA technology for the device to use.  This is necessary to define, control, and manage a mixed vendor environment where one needs a consistent way to define how all devices operate.  The *NetworkDirectTechnology defaults to device defined behavior for maximum compatibility.