### PR TITLE
Adding 'System' to the registry paths.

### DIFF
--- a/windows-driver-docs-pr/usbcon/usb-registry-settings-for-a-function-controller-driver.md
+++ b/windows-driver-docs-pr/usbcon/usb-registry-settings-for-a-function-controller-driver.md
@@ -28,7 +28,7 @@ OEMs must set several registry values to make sure that their device enumerates 
 
 Registry keys related to the device-side USB drivers are under:
 
-**HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**
+**HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**
 
 This topic describes settings for the preceding key and subkeys that define the device, configuration, and interface descriptors for the device.
 
@@ -37,7 +37,7 @@ This topic describes settings for the preceding key and subkeys that define the 
 
 Configuration information for the USB device are under:
 
-**HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**
+**HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**
 
 This table describes the subkeys that OEMs can modify under this key. More information about the supported values for each subkey is provided in sections below.
 
@@ -56,38 +56,38 @@ This table describes the subkeys that OEMs can modify under this key. More infor
 <tr class="odd">
 <td><strong>Alternates</strong></td>
 <td>This subkey contains additional subkeys that describe an interface that has one or more alternate settings:
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong></p></td>
 </tr>
 <tr class="even">
 <td><strong>Associations</strong></td>
 <td>This subkey defines Interface Association Descriptors (IADs). Each IAD allows multiple interfaces to be grouped into a single function. Each subkey represents a different IAD and OEMs can modify the values for those subkeys.
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong></p></td>
 </tr>
 <tr class="odd">
 <td><strong>Default</strong></td>
 <td>This subkey contains default values that are used to describe device-specific settings such as the VID and PID. This is a Microsoft-owned subkey whose values are overridden by those in the parent key:
-<p><strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong></p></td>
+<p><strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong></p></td>
 </tr>
 <tr class="even">
 <td><strong>Configurations</strong></td>
-<td>This subkey contains additional subkeys that contain configuration descriptor values that are used during USB enumeration. For example, the standard test configuration might exist under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Configurations</strong>\\<strong>TestConfigClassic</strong>.</td>
+<td>This subkey contains additional subkeys that contain configuration descriptor values that are used during USB enumeration. For example, the standard test configuration might exist under <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Configurations</strong>\\<strong>TestConfigClassic</strong>.</td>
 </tr>
 <tr class="odd">
 <td><strong>Configurations\Default</strong></td>
-<td>This subkey contains values for the default configuration. The interfaces in the default configuration are added before the current configuration present when the <strong>IncludeDefaultCfg</strong> value is set under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key.</td>
+<td>This subkey contains values for the default configuration. The interfaces in the default configuration are added before the current configuration present when the <strong>IncludeDefaultCfg</strong> value is set under the <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key.</td>
 </tr>
 <tr class="even">
 <td><strong>Interfaces</strong></td>
-<td>This subkey contains additional subkeys that describe specific interface descriptors. For example, the IP over USB configuration may reside under a subkey named <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>\\<strong>IpOverUsb</strong>. The name of this subkey for an interface is what determines the hardware ID of the class driver. In the IP over USB example, the _HID of the loaded PDO is <strong>USBFN\IpOverUsb</strong>.</td>
+<td>This subkey contains additional subkeys that describe specific interface descriptors. For example, the IP over USB configuration may reside under a subkey named <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>\\<strong>IpOverUsb</strong>. The name of this subkey for an interface is what determines the hardware ID of the class driver. In the IP over USB example, the _HID of the loaded PDO is <strong>USBFN\IpOverUsb</strong>.</td>
 </tr>
 </tbody>
 </table>
 
  
 
-This table describes the values that OEMs can modify in the **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN** key. Values that are not listed in this table assume the default values defined by Microsoft under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Default**.
+This table describes the values that OEMs can modify in the **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN** key. Values that are not listed in this table assume the default values defined by Microsoft under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Default**.
 
-All OEMs must set the **idVendor**, **idProduct**, **ManufacturerString**, and **ProductString** values. OEMs that create and add their own interfaces must also set **CurrentConfiguration** to the name of the subkey under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations** that includes their interfaces in the **InterfaceList**.
+All OEMs must set the **idVendor**, **idProduct**, **ManufacturerString**, and **ProductString** values. OEMs that create and add their own interfaces must also set **CurrentConfiguration** to the name of the subkey under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations** that includes their interfaces in the **InterfaceList**.
 
 | Value                    | Type       | Owner | Description                                                                                                                                                                                                                                                                                                                |
 |--------------------------|------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -103,7 +103,7 @@ All OEMs must set the **idVendor**, **idProduct**, **ManufacturerString**, and *
 ## USBFN\\Configurations registry key
 
 
-This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations**. Each subkey represents a different USB configuration. If the OEM wants to create their own interface, the OEM must define a new configuration which contains the interfaces to be used. To do this, create a subkey under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations** that uses the name of the configuration and populate the subkey with the values in this table. Additionally, for the USB driver to use the new configuration, the **CurrentConfiguration** value (described in the preceding table) must be set to the name of the configuration subkey.
+This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations**. Each subkey represents a different USB configuration. If the OEM wants to create their own interface, the OEM must define a new configuration which contains the interfaces to be used. To do this, create a subkey under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Configurations** that uses the name of the configuration and populate the subkey with the values in this table. Additionally, for the USB driver to use the new configuration, the **CurrentConfiguration** value (described in the preceding table) must be set to the name of the configuration subkey.
 
 <table>
 <colgroup>
@@ -125,14 +125,14 @@ This table describes the values that OEMs can modify for subkeys under **HKEY\_L
 <td><strong>InterfaceList</strong></td>
 <td>REG_MULTI_SZ</td>
 <td>OEM or Microsoft</td>
-<td><p>Contains a list of interface names that correspond to interface subkeys under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>, the IAD associations defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong>, and the alternate interfaces defined under <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong>. Those keys determine the interfaces that are used to describe the composite configuration descriptor.</p>
-<p>If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, this list is appended to the Microsoft-owned default interface list to create the complete interface list that the device will use to enumerate.</p></td>
+<td><p>Contains a list of interface names that correspond to interface subkeys under <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Interfaces</strong>, the IAD associations defined under <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Associations</strong>, and the alternate interfaces defined under <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong>\\<strong>Alternates</strong>. Those keys determine the interfaces that are used to describe the composite configuration descriptor.</p>
+<p>If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, this list is appended to the Microsoft-owned default interface list to create the complete interface list that the device will use to enumerate.</p></td>
 </tr>
 <tr class="even">
 <td><strong>MSOSCompatIdDescriptor</strong></td>
 <td>REG_BINARY</td>
 <td>OEM or Microsoft</td>
-<td><p>Optional. Defines an Extended Compat ID OS Feature Descriptor for the configuration. If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, the functions in this descriptor are appended to the functions and interfaces in the default configuration.</p></td>
+<td><p>Optional. Defines an Extended Compat ID OS Feature Descriptor for the configuration. If the <strong>IncludeDefaultCfg</strong> value under the <strong>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control</strong>\\<strong>USBFN</strong> key is set to 1, the functions in this descriptor are appended to the functions and interfaces in the default configuration.</p></td>
 </tr>
 </tbody>
 </table>
@@ -142,9 +142,9 @@ This table describes the values that OEMs can modify for subkeys under **HKEY\_L
 ## USBFN\\Interfaces registry key
 
 
-This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces**.
+This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces**.
 
-Each subkey represents a different USB interface. To define an interface, create a subkey under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces** using the name of the interface, and populate it with the values in the table below. Additionally, an interface will only be included if the interface is part of the **InterfaceList** of the **CurrentConfiguration**.
+Each subkey represents a different USB interface. To define an interface, create a subkey under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces** using the name of the interface, and populate it with the values in the table below. Additionally, an interface will only be included if the interface is part of the **InterfaceList** of the **CurrentConfiguration**.
 
 | Value                              | Type        | Owner            | Description                                                                                                                                                                                                                                                                                                  |
 |------------------------------------|-------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -158,13 +158,13 @@ Each subkey represents a different USB interface. To define an interface, create
 ## USBFN\\Alternates registry key
 
 
-The alternates subkey is used to define a single interface that has one or more alternate interfaces. This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Alternates**.
+The alternates subkey is used to define a single interface that has one or more alternate interfaces. This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Alternates**.
 
-Each subkey represents a different interface. To define an interface with alternate settings, create a subkey under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Alternates** by using the name of the interface, and populate it with the values in the table below.
+Each subkey represents a different interface. To define an interface with alternate settings, create a subkey under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Alternates** by using the name of the interface, and populate it with the values in the table below.
 
 | Value                              | Type           | Owner            | Description                                                                                                                                                                                                                                                                                                                                                        |
 |------------------------------------|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **InterfaceList**                  | REG\_MULTI\_SZ | OEM or Microsoft | A list of two of more interface names that correspond to interfaces defined under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces**. That key collectively defines an interface with alternate settings. The first interface corresponds to alternate setting 0, the second interface corresponds to alternate setting 1, and so on. |
+| **InterfaceList**                  | REG\_MULTI\_SZ | OEM or Microsoft | A list of two of more interface names that correspond to interfaces defined under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Interfaces**. That key collectively defines an interface with alternate settings. The first interface corresponds to alternate setting 0, the second interface corresponds to alternate setting 1, and so on. |
 | **InterfaceNumber**                | REG\_DWORD     | OEM or Microsoft | Optional. This value is used to assign a fixed interface number to a function. Interface numbers 0-1F are reserved for legacy functions, 20-3F are reserved for Microsoft, and 40-5F are reserved for use by OEMs.                                                                                                                                                 |
 | **MSOSExtendedPropertyDescriptor** | REG\_BINARY    | OEM or Microsoft | Optional. Defines an Extended Property OS Feature Descriptor for the interface.                                                                                                                                                                                                                                                                                    |
 
@@ -173,9 +173,9 @@ Each subkey represents a different interface. To define an interface with altern
 ## USBFN\\Associations registry key
 
 
-OEMs can specify associations by defining Interface Association Descriptors (IADs). Each IAD allows multiple interfaces to be grouped into a single function. This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Associations**.
+OEMs can specify associations by defining Interface Association Descriptors (IADs). Each IAD allows multiple interfaces to be grouped into a single function. This table describes the values that OEMs can modify for subkeys under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Associations**.
 
-Each subkey represents a different IAD. To define an association, create a subkey under **HKEY\_LOCAL\_MACHINE\\CurrentControlSet\\Control**\\**USBFN**\\**Associations** by using the name of the IAD, and populate it with the values in the table below.
+Each subkey represents a different IAD. To define an association, create a subkey under **HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control**\\**USBFN**\\**Associations** by using the name of the IAD, and populate it with the values in the table below.
 
 | Value                              | Type           | Owner            | Description                                                                                                                                                                                                                 |
 |------------------------------------|----------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
The registry paths didn't include the "System" key and it was confusing for the users when they tried to copy-paste the path.