### PR TITLE
Some layout fixes. Some wording fixes! Careful!

### DIFF
--- a/windows-driver-docs-pr/devtest/boot-options-in-a-boot-ini-file.md
+++ b/windows-driver-docs-pr/devtest/boot-options-in-a-boot-ini-file.md
@@ -14,29 +14,21 @@ ms.technology: windows-devices
 
 # Boot Options in a Boot.ini File
 
-
 \[This topic describes the boot options supported in Windows XP and Windows Server 2003. If you are changing boot options for Windows 8, Windows Server 2012, Windows 7, Windows Server 2008, or Windows Vista, see [Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md).\]
 
-Boot.ini is a text file located at the root of the system partition, typically c:\\Boot.ini. Boot.ini stores boot options for computers with BIOS firmware, traditionally, computers with x86 and x64-based processors.
+Boot.ini is a text file located at the root of the system partition, typically c:\\Boot.ini. Boot.ini stores boot options for computers with BIOS firmware, traditionally, computers with IA-32-based and x64-based processors. On Windows Server 2003 and earlier versions of the Windows NT family of operating systems, when the computer starts, the Windows boot loader, called "ntldr", reads the Boot.ini file and displays the entries for each operating system in the boot menu. Then, ntldr loads the selected operating system in accordance with settings in the Boot.ini file.
 
-## <span id="ddk_boot_options_in_a_boot_ini_file_tools"></span><span id="DDK_BOOT_OPTIONS_IN_A_BOOT_INI_FILE_TOOLS"></span>
+By default, on NTFS drives, the **system**, **hidden**, **archived**, and **read-only** attributes are set to protect Boot.ini; however, members of the Administrators group can change these attributes. The file attributes do not affect the operation of the boot loader.
 
-
-On Windows Server 2003 and earlier versions of NT-based Windows operating systems, when the computer starts, the Windows boot loader, Ntldr, reads the Boot.ini file and displays the entries for each operating system in the boot menu. Then, Ntldr loads the selected operating system in accordance with settings in the Boot.ini file.
-
-By default, on NTFS drives, the **system**, **hidden**, **archived**, and **read-only** attributes are set to protect the Boot.ini file; however, members of the Administrators group can change these attributes. The file attributes do not affect the operation of boot loader.
-
-The following sections briefly describe the Boot.ini file and explain the aspects of boot options that are specific to computers with Personal Computer Advanced Technology (PC/AT)-type BIOS firmware.
+The following sections briefly describe Boot.ini and explain the aspects of boot options that are specific to computers with Personal Computer Advanced Technology (PC/AT)-type BIOS firmware.
 
 This section includes:
 
-[Overview of the Boot.ini File](overview-of-the-boot-ini-file.md)
+- [Overview of the Boot.ini File](overview-of-the-boot-ini-file.md)
+- [Editing the Boot.ini File](editing-the-boot-ini-file.md)
+- [Backing Up the Boot.ini File](backing-up-the-boot-ini-file.md)
 
-[Editing the Boot.ini File](editing-the-boot-ini-file.md)
-
-[Backing Up the Boot.ini File](backing-up-the-boot-ini-file.md)
-
-This document describes aspects of the Boot.ini file that are of special interest to driver developers and testers. For a complete list of the Boot.ini file parameters, see [Available Switch Options for the Windows XP and the Windows Server 2003 Boot.ini Files](http://go.microsoft.com/fwlink/p/?linkid=137742) topic in the Microsoft Knowledge Base.
+This document describes aspects of Boot.ini that are of special interest to driver developers and testers. For a complete list of Boot.ini parameters, see [Available Switch Options for the Windows XP and the Windows Server 2003 Boot.ini Files](http://go.microsoft.com/fwlink/p/?linkid=137742) topic on the Microsoft Support website.
 
  
 

--- a/windows-driver-docs-pr/devtest/boot-options-in-a-boot-ini-file.md
+++ b/windows-driver-docs-pr/devtest/boot-options-in-a-boot-ini-file.md
@@ -6,7 +6,7 @@ keywords:
 - Boot.ini files WDK
 - boot options WDK , Boot.ini files
 ms.author: windowsdriverdev
-ms.date: 04/20/2017
+ms.date: 07/02/2018
 ms.topic: article
 ms.prod: windows-hardware
 ms.technology: windows-devices
@@ -14,7 +14,7 @@ ms.technology: windows-devices
 
 # Boot Options in a Boot.ini File
 
-\[This topic describes the boot options supported in Windows XP and Windows Server 2003. If you are changing boot options for Windows 8, Windows Server 2012, Windows 7, Windows Server 2008, or Windows Vista, see [Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md).\]
+[!IMPORTANT] This topic describes the boot options supported in Windows XP and Windows Server 2003. If you are changing boot options for Windows 8, Windows Server 2012, Windows 7, Windows Server 2008, or Windows Vista, see [Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md).\]
 
 Boot.ini is a text file located at the root of the system partition, typically c:\\Boot.ini. Boot.ini stores boot options for computers with BIOS firmware, traditionally, computers with IA-32-based and x64-based processors. On Windows Server 2003 and earlier versions of the Windows NT family of operating systems, when the computer starts, the Windows boot loader, called "ntldr", reads the Boot.ini file and displays the entries for each operating system in the boot menu. Then, ntldr loads the selected operating system in accordance with settings in the Boot.ini file.
 

--- a/windows-driver-docs-pr/devtest/introduction-to-boot-options.md
+++ b/windows-driver-docs-pr/devtest/introduction-to-boot-options.md
@@ -15,11 +15,7 @@ ms.technology: windows-devices
 
 # Introduction to Boot Options
 
-
 The concept and content of boot options are very similar on all computers that run Microsoft Windows operating systems. However, prior to Windows Vista, computers with different processor firmware store boot options differently and require different tools to view and edit the options on each system.
-
-## <span id="ddk_introduction_to_boot_options_tools"></span><span id="DDK_INTRODUCTION_TO_BOOT_OPTIONS_TOOLS"></span>
-
 
 <table>
 <colgroup>
@@ -34,27 +30,13 @@ The concept and content of boot options are very similar on all computers that r
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><p><span id="______Windows_7__Windows_Server_2008__Windows_Vista"></span><span id="______windows_7__windows_server_2008__windows_vista"></span><span id="______WINDOWS_7__WINDOWS_SERVER_2008__WINDOWS_VISTA"></span>Windows 10, Windows 8, Windows Server 2012, Windows 7, Windows Server 2008, Windows Vista</p></td>
+<td align="left"><p><span id="______Windows_7__Windows_Server_2008__Windows_Vista"></span><span id="______windows_7__windows_server_2008__windows_vista"></span><span id="______WINDOWS_7__WINDOWS_SERVER_2008__WINDOWS_VISTA"></span>Windows Server 2016, Windows 10, Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista</p></td>
 <td align="left"><p>Windows Vista, and later versions of Windows, store boot option in a firmware-independent storage and configuration system. Windows Vista also introduces a new Boot Manager and system-specific boot loaders. For more information, see [Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md).</p></td>
 </tr>
 </tbody>
 </table>
 
- 
-
 This section includes:
-
-[Boot Options in a Boot.ini File](boot-options-in-a-boot-ini-file.md) (Windows XP, Windows Server 2003)
-
-[Boot Options in EFI NVRAM](boot-options-in-efi-nvram.md) (Windows XP, Windows Server 2003)
-
-[Overview of Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md) (Windows 8, Windows Server 2012, Windows 7, Windows Server 2008)
-
- 
-
- 
-
-
-
-
-
+- [Boot Options in a Boot.ini File](boot-options-in-a-boot-ini-file.md) (Windows XP, Windows Server 2003)
+- [Boot Options in EFI NVRAM](boot-options-in-efi-nvram.md) (Windows XP, Windows Server 2003)
+- [Overview of Boot Options in Windows Vista and Later](boot-options-in-windows-vista-and-later.md)

--- a/windows-driver-docs-pr/devtest/introduction-to-boot-options.md
+++ b/windows-driver-docs-pr/devtest/introduction-to-boot-options.md
@@ -7,7 +7,7 @@ keywords:
 - storing boot options
 - boot loaders WDK
 ms.author: windowsdriverdev
-ms.date: 04/20/2017
+ms.date: 07/02/2018
 ms.topic: article
 ms.prod: windows-hardware
 ms.technology: windows-devices


### PR DESCRIPTION
This pull request goes a little beyond the cosmetic changes that Microsoft has already approved of (as seen in my previous requests). It has wording changes.

Summary:
- I replaced all repetitions of "the Boot.ini file". One doesn't need to say that Boot.ini is a file every time one mentions it. Once is enough. This principle was already observed regarding "ntldr". 
- "NT-based operating systems" is wrong in this context; e.g. Windows 8.1 is not a fork of Windows NT, but a version of it. If you ask PowerShell or Windows API, it'll tell you that, e.g. Windows 8.1 is still "Windows NT 6.3.9600". 
- "Microsoft Knowledge Base" stopped being the title of that certain website 10 years ago.

I'll keep my fingers crossed! 😉