### PR TITLE
Adding a link for a mandatory interface for device MFT

### DIFF
--- a/windows-driver-docs-pr/stream/dmft-design.md
+++ b/windows-driver-docs-pr/stream/dmft-design.md
@@ -232,6 +232,8 @@ Device MFTs must support the following interfaces:
 
 - [IMFRealtimeClientEx](https://msdn.microsoft.com/library/windows/desktop/hh448047)
 
+- [IMFMediaEventGenerator] (https://docs.microsoft.com/en-us/windows/desktop/api/mfobjects/nn-mfobjects-imfmediaeventgenerator)
+
 - [IMFShutdown](https://msdn.microsoft.com/library/windows/desktop/ms703054)
 
 ### Notification Requirements


### PR DESCRIPTION
Device MFT also needs the IMFMediaEventGenerator along with the other listed. Adding the interface and the link for the interface