### PR TITLE
Minor layout fix

### DIFF
--- a/windows-driver-docs-pr/debugger/debugger-download-symbols.md
+++ b/windows-driver-docs-pr/debugger/debugger-download-symbols.md
@@ -11,7 +11,7 @@ ms.technology: windows-devices
 
 # Windows Symbol Packages
 
-Symbol files make it easier to debug your code. The easiest way to get Windows symbols is to use the [Microsoft public symbol server](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols). The symbol server makes symbols available to your debugging tools as needed. After a symbol file is downloaded from the symbol server it is cached on the local computer for quick access. 
+Symbol files make it easier to debug your code. The easiest way to get Windows symbols is to use the [Microsoft public symbol server](microsoft-public-symbols.md). The symbol server makes symbols available to your debugging tools as needed. After a symbol file is downloaded from the symbol server it is cached on the local computer for quick access. 
 
 
 ## Symbol package deprecation
@@ -23,13 +23,13 @@ Symbol files make it easier to debug your code. The easiest way to get Windows s
 > We have made significant improvements to the online [Microsoft Symbol Server](microsoft-public-symbols.md) by moving this to be an Azure-based symbol store, and symbols for all Windows versions and updates are available there. 
 > You can find more about this in this [blog entry](https://blogs.msdn.microsoft.com/windbg/2017/10/18/update-on-microsofts-symbol-server/). 
 >
-> For information on how to retrieve symbols for a machine that is not connected to the Internet, see [Using a Manifest File with SymChk](https://docs.microsoft.com/windows-hardware/drivers/debugger/using-a-manifest-file-with-symchk).
+> For information on how to retrieve symbols for a machine that is not connected to the Internet, see [Using a Manifest File with SymChk](using-a-manifest-file-with-symchk.md).
 
 ## Symbol Resources and Feedback
 
-To learn more about using symbols and debugging, see [Symbols and Symbol Files](https://docs.microsoft.com/windows-hardware/drivers/debugger/symbols-and-symbol-files). 
+To learn more about using symbols and debugging, see [Symbols and Symbol Files](symbols-and-symbol-files.md).
 
-For help with debugging issues, see [Debugging Resources](https://docs.microsoft.com/windows-hardware/drivers/debugger/debugging-resources). 
+For help with debugging issues, see [Debugging Resources](debugging-resources.md). 
 
 We are interested in your feedback about symbols. Please mail suggestions or bug reports to [windbgfb@microsoft.com](mailto:windbgfb@microsoft.com). Technical support is not available from this address, but your feedback will help us to plan future changes for symbols and will make them more useful to you in the future. 
 

--- a/windows-driver-docs-pr/debugger/debugger-download-symbols.md
+++ b/windows-driver-docs-pr/debugger/debugger-download-symbols.md
@@ -9,12 +9,12 @@ ms.prod: windows-hardware
 ms.technology: windows-devices
 ---
 
-## Windows Symbol Packages
+# Windows Symbol Packages
 
 Symbol files make it easier to debug your code. The easiest way to get Windows symbols is to use the [Microsoft public symbol server](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols). The symbol server makes symbols available to your debugging tools as needed. After a symbol file is downloaded from the symbol server it is cached on the local computer for quick access. 
 
 
-### Symbol package deprecation
+## Symbol package deprecation
 
 > [!IMPORTANT]
 > We are no longer publishing the offline symbol packages for Windows.
@@ -23,8 +23,7 @@ Symbol files make it easier to debug your code. The easiest way to get Windows s
 > We have made significant improvements to the online [Microsoft Symbol Server](microsoft-public-symbols.md) by moving this to be an Azure-based symbol store, and symbols for all Windows versions and updates are available there. 
 > You can find more about this in this [blog entry](https://blogs.msdn.microsoft.com/windbg/2017/10/18/update-on-microsofts-symbol-server/). 
 >
-> For information on how to retrieve symbols for a machine that is not connected to the Internet, see [Using a Manifest File with SymChk](https://docs.microsoft.com/windows-hardware/drivers/debugger/using-a-manifest-file-with-symchk). 
->  
+> For information on how to retrieve symbols for a machine that is not connected to the Internet, see [Using a Manifest File with SymChk](https://docs.microsoft.com/windows-hardware/drivers/debugger/using-a-manifest-file-with-symchk).
 
 ## Symbol Resources and Feedback
 
@@ -32,30 +31,16 @@ To learn more about using symbols and debugging, see [Symbols and Symbol Files](
 
 For help with debugging issues, see [Debugging Resources](https://docs.microsoft.com/windows-hardware/drivers/debugger/debugging-resources). 
 
-
-
 We are interested in your feedback about symbols. Please mail suggestions or bug reports to [windbgfb@microsoft.com](mailto:windbgfb@microsoft.com). Technical support is not available from this address, but your feedback will help us to plan future changes for symbols and will make them more useful to you in the future. 
-
-
-
-
--------------------
 
 ## Looking for related downloads?
 
-[Download Windows Debugging Tools](debugger-download-tools.md) 
+- [Download Windows Debugging Tools](debugger-download-tools.md)
 
-[Download the Windows Driver Kit (WDK)](https://developer.microsoft.com/windows/hardware/windows-driver-kit) 
+- [Download the Windows Driver Kit (WDK)](https://developer.microsoft.com/windows/hardware/windows-driver-kit)
 
-[Download the Windows Assessment and Deployment Kit (Windows ADK)](https://developer.microsoft.com/windows/hardware/windows-assessment-deployment-kit) 
+- [Download the Windows Assessment and Deployment Kit (Windows ADK)](https://developer.microsoft.com/windows/hardware/windows-assessment-deployment-kit)
 
-[Download the Windows HLK, HCK, or Logo Kit](https://developer.microsoft.com/windows/hardware/windows-hardware-lab-kit) 
+- [Download the Windows HLK, HCK, or Logo Kit](https://developer.microsoft.com/windows/hardware/windows-hardware-lab-kit)
 
-[Download Windows Insider Preview builds](https://insider.windows.com/) 
- 
-
-
-
-
-
-
+- [Download Windows Insider Preview builds](https://insider.windows.com/)


### PR DESCRIPTION
The "Symbol package deprecation" section was L3 instead of L2. As such it didn't appear in the TOC. Also, I formatted a list so that it looks like ... a list.