### PR TITLE
Outdated info: No more offline symbols

### DIFF
--- a/windows-driver-docs-pr/debugger/installing-windows-symbol-files.md
+++ b/windows-driver-docs-pr/debugger/installing-windows-symbol-files.md
@@ -12,47 +12,15 @@ ms.technology: windows-devices
 
 # Installing Windows Symbol Files
 
-
-## <span id="ddk_installing_windows_symbol_files_dbg"></span><span id="DDK_INSTALLING_WINDOWS_SYMBOL_FILES_DBG"></span>
-
-
-Before you debug the Windows kernel or a driver or application running on Windows, you need access to the proper symbol files.
-
-The easiest way to get Windows symbols is to use the Microsoft Symbol Server. The symbol server makes symbols available to your debugging tools as needed. After a symbol file is downloaded from the symbol server it is cached on the local computer for quick access. Additional versions of Windows not listed here, are available on the Microsoft Symbol Server. 
+Before you debug the Windows kernel, a driver or app, you need access to the proper symbol files. The official way to get Windows symbols is to use the Microsoft Symbol Server. The symbol server makes symbols available to your debugging tools as needed. After a symbol file is downloaded from the symbol server it is cached on the local computer for quick access. 
 
 You can connect to the Microsoft Symbol Server with one simple use of the [**.symfix (Set Symbol Store Path)**](-symfix--set-symbol-store-path-.md) command. For full details, see [Microsoft Public Symbols](microsoft-public-symbols.md).
 
-If you plan to install symbols manually, it is crucial that you remember this basic rule: *the symbol files on the host computer are required to match the version of Windows installed on the target computer.*  
+> [!IMPORTANT]
+> We are no longer publishing the offline symbol packages for Windows. The faster Windows update cadence means the Windows debugging symbols are quickly made out of  date. We have made significant improvements to the online [Microsoft Symbol Server](microsoft-public-symbols.md) where symbols for all Windows versions and updates are available. You can find more about this in this [blog entry](https://blogs.msdn.microsoft.com/windbg/2017/10/18/update-on-microsofts-symbol-server/). 
+>
+> For information on how to retrieve symbols for a machine that is not connected to the Internet, see [Using a Manifest File with SymChk](using-a-manifest-file-with-symchk.md).
 
-If you plan to perform user-mode debugging on the same computer as the target application, then install the symbol files that match the version of Windows running on that system. If you are analyzing a memory dump file, then the version of symbol files needed on the debug computer are those that match the version of the operating system that produced the dump file, not necessarily those matching the version of the operating system on the machine running the debug session.
+If you are going to debug a user-mode app, you need to install the symbols for this app as well.
 
-**Note**   If you are going to use your host computer to debug several different target computers, you may need symbols for more than one build of Windows. In this case, be sure to install each symbol collection in a distinct directory path.
-
-
-If you are debugging from a Windows computer attached to a network, it may be useful to install symbols for a variety of different builds on a network server. Microsoft debuggers will accept a network path (*\\\\server\\share\\dir*) as a valid symbol directory path. This avoids the need for each debugging computer on the network to install the symbol files separately.
-
-Symbol files stored on a crashed target computer are not usable by the debugger on the host computer.
-
-**To install Windows symbol files**
-
-1.  Make sure you have sufficient space on the disk drive of the host computer.
-
-2.  Open [Download Windows Symbol Packages](http://go.microsoft.com/fwlink/p/?linkid=17363).
-
-3.  Follow the links to download and install the desired symbol package.
-
-
-### <span id="installing_user_mode_symbols"></span><span id="INSTALLING_USER_MODE_SYMBOLS"></span>Installing User-Mode Symbols
-
-If you are going to debug a user-mode application, you need to install the symbols for this application as well.
-
-You can debug an application if you have its symbols but not Windows symbols. However, your results will be much more limited. You will still be able to step through the application code, but any debugger activity which requires analysis of the kernel (such as getting a stack trace) is likely to fail.
-
- 
-
- 
-
-
-
-
-
+You can debug an app if you have its symbols but not Windows symbols. However, your results will be much more limited. You will still be able to step through the app code, but any debugger activity which requires analysis of the kernel (such as getting a stack trace) is likely to fail.


### PR DESCRIPTION
1. Replaced outdated info with a notice from Microsoft. There are major deletions, and addition of one notice. 
2. An unused but visible anchor was deleted.
3. Replaced the outdated and ambiguous word "application" with "app". "App" is what Microsoft uses to refer to all computer programs nowadays. "Application", on the other hand, often stands in contrast with "Utility". Utility software can be debugged in pretty much the same way.