### PR TITLE
Update hardware-support-app--hsa--steps-for-driver-developers.md

### DIFF
--- a/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
+++ b/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
@@ -37,7 +37,7 @@ First, reserve a custom capability:
     * What resources does capability need to access?
     * Any security or privacy concerns
     * What data does your capability provide access to?
-    * Include the Microsoft Store App Publisher ID.  To get one, create a skeleton app entry on the Microsoft Store page. For more info on reserving your App PFN, see [Create your app by reserving a name](https://msdn.microsoft.com/en-us/windows/uwp/publish/create-your-app-by-reserving-a-name).
+    * Include the Microsoft Store App Publisher ID.  To get one, create a skeleton app entry on the Microsoft Store page. For more info on reserving your App PFN, see [Create your app by reserving a name](https://msdn.microsoft.com/windows/uwp/publish/create-your-app-by-reserving-a-name).
 
 2.  If the request is approved, Microsoft emails back a unique custom capability string name in the format **CompanyName.capabilityName\_PublisherID**.
 
@@ -142,7 +142,7 @@ To do so, before getting the SCCD signed by Microsoft, add **DeveloperModeOnly**
 </CustomCapabilityDescriptor>
 ```
 
-The resulting signed SCCD works only on devices in [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development). 
+The resulting signed SCCD works only on devices in [Developer Mode](https://docs.microsoft.com/windows/uwp/get-started/enable-your-device-for-development). 
 
 ## Summary
 
@@ -155,10 +155,10 @@ The following diagram summarizes the sequence described above:
 * [Getting Started with Universal Windows drivers](../develop/getting-started-with-universal-drivers.md)
 * [Intro to the Universal Windows Platform](https://docs.microsoft.com/windows/uwp/get-started/universal-application-platform-guide)
 * [Universal Windows Platform (UWP)](https://docs.microsoft.com/windows/uwp/design/basics/design-and-ui-intro)
-* [App capabilities](https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations)
-* [Develop UWP apps using Visual Studio](https://developer.microsoft.com/en-us/windows/apps/develop)
+* [App capabilities](https://docs.microsoft.com/windows/uwp/packaging/app-capability-declarations)
+* [Develop UWP apps using Visual Studio](https://developer.microsoft.com/windows/apps/develop)
 * [Pairing a driver with a Universal Windows Platform (UWP) app](../install/pairing-app-and-driver-versions.md)
-* [Develop UWP apps](https://developer.microsoft.com/en-us/windows/apps/develop)
+* [Develop UWP apps](https://developer.microsoft.com/windows/apps/develop)
 * [Package an app using the Desktop App Converter (Desktop Bridge)](https://docs.microsoft.com/windows/uwp/porting/desktop-to-uwp-run-desktop-app-converter)
 * [Custom Capability Sample App](http://go.microsoft.com/fwlink/p/?LinkId=846904)
 * [Custom Capability Driver Sample](https://aka.ms/customcapabilitydriversample )

--- a/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
+++ b/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
@@ -268,7 +268,7 @@ The following is the formal XML XSD schema for an SCCD file.  Use this schema to
 </xs:schema>
 ```
 
-The following schema is also valid as of the the Redstone 5 release.  It enbales a SCCD to declare any app package to be an authorized entity. 
+The following schema is also valid as of Windows 10, version 1809.  It enables a SCCD to declare any app package to be an authorized entity. 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
+++ b/windows-driver-docs-pr/devapps/hardware-support-app--hsa--steps-for-driver-developers.md
@@ -267,3 +267,105 @@ The following is the formal XML XSD schema for an SCCD file.  Use this schema to
 
 </xs:schema>
 ```
+
+The following schema is also valid as of the the Redstone 5 release.  It enbales a SCCD to declare any app package to be an authorized entity. 
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://schemas.microsoft.com/appx/2018/sccd"
+  xmlns:s="http://schemas.microsoft.com/appx/2018/sccd"
+  xmlns="http://schemas.microsoft.com/appx/2018/sccd">
+
+  <xs:element name="CustomCapabilityDescriptor" type="CT_CustomCapabilityDescriptor">
+    <xs:unique name="Unique_CustomCapability_Name">
+      <xs:selector xpath="s:CustomCapabilities/s:CustomCapability"/>
+      <xs:field xpath="@Name"/>
+    </xs:unique>
+  </xs:element>
+
+  <xs:complexType name="CT_CustomCapabilityDescriptor">
+    <xs:sequence>
+      <xs:element ref="CustomCapabilities" minOccurs="1" maxOccurs="1"/>
+      <xs:element ref="AuthorizedEntities" minOccurs="1" maxOccurs="1"/>
+      <xs:element ref="DeveloperModeOnly" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="Catalog" minOccurs="1" maxOccurs="1"/>
+      <xs:any minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:element name="CustomCapabilities" type="CT_CustomCapabilities" />
+
+  <xs:complexType name="CT_CustomCapabilities">
+    <xs:sequence>
+      <xs:element ref="CustomCapability" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="CustomCapability">
+    <xs:complexType>
+      <xs:attribute name="Name" type="ST_CustomCapability" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="ST_NonEmptyString">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="32767"/>
+      <xs:pattern value="[^\s]|([^\s].*[^\s])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_CustomCapability">
+    <xs:annotation>
+      <xs:documentation>Custom capabilities should be a string in the form of Company.capabilityName_PublisherId</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="ST_NonEmptyString">
+      <xs:pattern value="[A-Za-z0-9][-_.A-Za-z0-9]*_[a-hjkmnp-z0-9]{13}"/>
+      <xs:minLength value="15"/>
+      <xs:maxLength value="255"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="AuthorizedEntities" type="CT_AuthorizedEntities" />
+
+  <xs:complexType name="CT_AuthorizedEntities">
+    <xs:sequence>
+      <xs:element ref="AuthorizedEntity" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="AllowAny" type="xs:boolean" use="optional"/>
+  </xs:complexType>
+  
+  <xs:element name="AuthorizedEntity" type="CT_AuthorizedEntity" />
+  
+  <xs:complexType name="CT_AuthorizedEntity">
+    <xs:attribute name="CertificateSignatureHash" type="ST_CertificateSignatureHash" use="required"/>
+    <xs:attribute name="AppPackageFamilyName" type="ST_NonEmptyString" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ST_CertificateSignatureHash">
+    <xs:restriction base="ST_NonEmptyString">
+      <xs:pattern value="[A-Fa-f0-9]+"/>
+      <xs:minLength value="64"/>
+      <xs:maxLength value="64"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="DeveloperModeOnly">
+    <xs:complexType>
+      <xs:attribute name="Value" type="xs:boolean" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="Catalog" type="ST_Catalog" />
+
+  <xs:simpleType name="ST_Catalog">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z0-9\+\/\=]+"/>
+      <xs:minLength value="4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+</xs:schema>
+```


### PR DESCRIPTION
This is a new RS5 schema.  

Should we also add how to find the app's signature hash?  It is a a common question.

The basic answer is it is found by dumping the CodeIntegrity.cat file found in the [appx package root]\AppxMetadata\CodeIntegrity.cat using certutil.exe.  It basically the last hash dumped.

The output looks something like: 
[appx package root]\AppxMetadata>certutil.exe CodeIntegrity.cat 
...
Signature Hash: 06633c347e5ffd6763f4329ca7f4c8d867b6b1e087b515caded70490ae7bffff
----------------  End Nesting Level 1  ----------------
No CRLs
CertUtil: -dump command completed successfully.
>