### PR TITLE
Incorrect Altitude for Fileinfo filter driver

### DIFF
--- a/windows-driver-docs-pr/ifs/allocated-altitudes.md
+++ b/windows-driver-docs-pr/ifs/allocated-altitudes.md
@@ -1555,7 +1555,7 @@ The current altitude allocations are listed for each of the following load order
 | aictracedrv\_b.sys  | 47000    | AI Consulting      |
 | hhdcfltr.sys        | 46900    | Seagate Technology |
 | Npsvctrig.sys       | 46000    | Microsoft          |
-| fileinfo            | 40500    | Microsoft          |
+| fileinfo            | 45000    | Microsoft          |
 | klvfs.sys           | 44900    | Kaspersky Lab      |
 | rsfxdrv.sys         | 41000    | Microsoft          |
 | defilter.sys        | 40900    | Microsoft          |


### PR DESCRIPTION
was 40500 , must be 45000. Here is the output from a system showing the correct number
Filter                Volume Name                              Altitude        Instance Name       Frame   SprtFtrs  VlStatus
--------------------  -------------------------------------  ------------  ----------------------  -----   --------  --------
FileInfo              \Device\HarddiskVolume12                   45000     FileInfo                  0     00000003  Detached
FileInfo              \Device\HarddiskVolume15                   45000     FileInfo                  0     00000003  Detached
FileInfo              \Device\HarddiskVolume18                   45000     FileInfo                  0     00000003  Detached
FileInfo              G:                                         45000     FileInfo                  0     00000003