### PR TITLE
Update system-defined-device-setup-classes-available-to-vendors.md

### DIFF
--- a/windows-driver-docs-pr/install/system-defined-device-setup-classes-available-to-vendors.md
+++ b/windows-driver-docs-pr/install/system-defined-device-setup-classes-available-to-vendors.md
@@ -60,11 +60,6 @@ Class = FloppyDisk
 ClassGuid= {4d36e980-e325-11ce-bfc1-08002be10318}  
 This class includes floppy disk drives.  
   
-**Global Positioning System/Global Navigation Satellite System**  
-Class = GPS  
-ClassGuid = {6bdd1fc3-810f-11d0-bec7-08002be2092f}  
-This class includes GNSS devices that use the Universal Windows driver model introduced in Windows 10.  
-  
 <a href="" id="hard-disk-controllers-"></a>**Hard Disk Controllers**  
 Class = HDC  
 ClassGuid = {4d36e96a-e325-11ce-bfc1-08002be10318}  


### PR DESCRIPTION
GPS device class is not defined in the OS itself and as a result, INFs cannot use the class without a ClassInstall32 section.  A universal driver cannot have a ClassInstall32 section (and even if they did, we don't want them to ClassInstall32 a system defined class).  This entry is causing confusion, so it should be removed for now