### PR TITLE
Fixed an issue I introduced in my original description

### DIFF
--- a/windows-driver-docs-pr/sensors/light-sensor-data-fields.md
+++ b/windows-driver-docs-pr/sensors/light-sensor-data-fields.md
@@ -62,7 +62,7 @@ The following table shows the data fields. For more information about the types 
 <td><p>PKEY_SensorData_IsValid</p></td>
 <td><p>VT_BOOL</p></td>
 <td><p>Optional</p></td>
-<td><p>This value must be set to TRUE when the ambient light sensor cannot currently return any valid sample. For example, this value may be set to TRUE when the sensor field of view is obstructed (such as when an object, or the user hand is in front of the sensor). This value should be set to FALSE when the ambient light sensor is able to accurately measure the ambient light. Proper hardware design should try to minimize the time and scenarios requiring this value to be set to TRUE as such scenario prevents the system from properly controlling brightness. On an ideal system, this value is always set to FALSE.</p></td>
+<td><p>This value must be set to FALSE when the ambient light sensor cannot currently return any valid sample. For example, this value may be set to FALSE when the sensor field of view is obstructed (such as when an object, or the user hand is in front of the sensor). This value should be set to TRUE when the ambient light sensor is able to accurately measure the ambient light. Proper hardware design should try to minimize the time and scenarios requiring this value to be set to FALSE as such scenario prevents the system from properly controlling brightness. On an ideal system, this value is always set to TRUE.</p></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
I mistakenly inverted the logic when writing the description of the property. PKEY_SensorData_IsValid should be set to TRUE when the sensor sample is valid.