### PR TITLE
Update DVL documentation to reflect SDV/CA order.

### DIFF
--- a/windows-driver-docs-pr/develop/creating-a-driver-verification-log.md
+++ b/windows-driver-docs-pr/develop/creating-a-driver-verification-log.md
@@ -8,18 +8,20 @@ ms.localizationpriority: medium
 
 # Creating a Driver Verification Log
 
-The Windows Server 2012 [Hardware Certification Program](https://go.microsoft.com/fwlink/p/?linkid=227016) requires a Driver Verification Log (DVL) for all applicable driver submissions. The DVL contains a summary of the results from the Code Analysis and Static Driver Verifier log files. The DVL does not contain any source information. You must run the Code Analysis tool and Static Driver Verifier prior to creating a DVL for your driver.
+The Windows Server [Hardware Certification Program](https://docs.microsoft.com/en-us/windows-hardware/design/compatibility/) requires a Driver Verification Log (DVL) for all driver submissions. The DVL contains a summary of the results from the Code Analysis (CA) and Static Driver Verifier (SDV) log files. The DVL does not contain any source information. You must run the Code Analysis tool and Static Driver Verifier prior to creating a DVL for your driver.
 
 **To create a driver verification log**
 
-1.  Before running the Code Analysis tools, be sure that you can build and link your driver using the Windows Driver Kit (WDK) for Windows 8.
-2.  For the Driver Solution, make sure that you have selected Windows 8 as the Solution Configuration and x64 as the Solution Platform.
-3.  Run the Code Analysis tool for drivers. Address and fix any defects that are found. See [Creating a log file for the code analysis tool](creating-a-log-file-for-the-code-analysis-tool.md) and [How to run Code Analysis for Drivers](https://msdn.microsoft.com/Library/Windows/Hardware/Hh454219). For more information about code analysis, see [Analyzing C/C++ Code Quality by Using Code Analysis](https://go.microsoft.com/fwlink/p/?linkid=226836).
-4.  Run [Static Driver Verifier](https://msdn.microsoft.com/Library/Windows/Hardware/Ff552808). For information about creating the log file, see [Creating a log file for Static Driver Verifier](creating-a-log-file-for-static-driver-verifier.md) and [Using Static Driver Verifier to find defects in drivers](https://msdn.microsoft.com/Library/Windows/Hardware/Hh454281).
+1.  Before running the Code Analysis tools, be sure that you can build and link your driver using the latest Windows Driver Kit (WDK).
+2.  For the Driver Solution, make sure that you have selected a Release configuration as the Solution Configuration and x64 as the Solution Platform.
+3.  Run [Static Driver Verifier](https://msdn.microsoft.com/Library/Windows/Hardware/Ff552808). For information about creating the log file, see [Creating a log file for Static Driver Verifier](creating-a-log-file-for-static-driver-verifier.md) and [Using Static Driver Verifier to find defects in drivers](https://msdn.microsoft.com/Library/Windows/Hardware/Hh454281).
+4.  Run the Code Analysis tool for drivers. Address and fix any defects that are found. See [Creating a log file for the code analysis tool](creating-a-log-file-for-the-code-analysis-tool.md) and [How to run Code Analysis for Drivers](https://msdn.microsoft.com/Library/Windows/Hardware/Hh454219). For more information about code analysis, see [Analyzing C/C++ Code Quality by Using Code Analysis](https://go.microsoft.com/fwlink/p/?linkid=226836).
 5.  Create the Driver Verification Log. From the **Driver** menu, click **Create Driver Verification Log...**.
 6.  Verify that both the Code Analysis Log and the Static Driver Verifier Log files are detected. Click **Create**.
 
 The driver verification log has the file name extension .DVL.XML. The log is created in the project folder, for example, \\*myDriverProject*\\*myDriverName*.DVL.XML.
+
+**Note**  SDV performs a clean rebuild of the driver, which removes the Code Analysis log.  As such, please be sure to run SDV before running CA.
 
 **Note**  When you are ready to test your driver using the [Windows Hardware Certification Kit (HCK)](https://go.microsoft.com/fwlink/p/?linkid=254893), you need to copy the driver verification log to the %systemdrive%\\DVL directory on the test computer. Be sure to delete the contents of the directory on the test computer before you copy the new driver verification log.
 
@@ -34,22 +36,10 @@ For the most up-to-date information about the Code Analysis tool, Static Driver 
 
  
 
-You can also create the driver verification log from a Visual Studio Command Prompt window. Set up the environment by running one of the following batch files.
+You can also create the driver verification log from a Visual Studio Command Prompt window, either by the Visual Studio Native Tools Command Prompt installed with Visual Studio or via the Enterprise Windows Driver Kit (EWDK):
 
 ```cpp
-"C:\Program Files\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x64
-```
-
--Or-
-
-```cpp
-"C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x64
-```
-
-Create the driver verification log.
-
-```cpp
-msbuild.exe <vcxprojectfile> /target:dvl /p:Configuration="Win8 Release" /P:Platform=x64
+msbuild.exe <vcxprojectfile> /target:dvl /p:Configuration="Release" /P:Platform=x64
 ```
 
 ## <span id="related_topics"></span>Related topics


### PR DESCRIPTION
SDV dev here.  SDV performs a clean rebuild of drivers, which removes the Code Analysis log as a result.  This change specifies that SDV must be run *before* CA to keep both logs for generating a DVL.

Also removing some outdated language that refers to Win8/Server 2012.