### PR TITLE
Adding a link to the light sensor whitepaper

### DIFF
--- a/windows-driver-docs-pr/sensors/testing-sensor-landing.md
+++ b/windows-driver-docs-pr/sensors/testing-sensor-landing.md
@@ -16,4 +16,4 @@ This section provides handy links to content relevant to sensor testing.
 - [SensorExplorer app](https://aka.ms/sensorexplorer) or [source](https://github.com/Microsoft/busiotools/tree/master/sensors/Tools/SensorExplorer)
 - [Tracing and logging scripts](https://github.com/Microsoft/busiotools/blob/master/sensors/tracing/README.md)
 - [Building a Light Testing Tool](testing-MALT-building-a-light-testing-tool.md)
-- [Light Sensor Guidance and Manual Testing](https://docs.microsoft.com/en-us/windows-hardware/design/whitepapers/integrating-ambient-light-sensors-with-computers-running-windows-10-creators-update)
+- [Light Sensor Guidance and Manual Testing](https://docs.microsoft.com/windows-hardware/design/whitepapers/integrating-ambient-light-sensors-with-computers-running-windows-10-creators-update)

--- a/windows-driver-docs-pr/sensors/testing-sensor-landing.md
+++ b/windows-driver-docs-pr/sensors/testing-sensor-landing.md
@@ -16,3 +16,4 @@ This section provides handy links to content relevant to sensor testing.
 - [SensorExplorer app](https://aka.ms/sensorexplorer) or [source](https://github.com/Microsoft/busiotools/tree/master/sensors/Tools/SensorExplorer)
 - [Tracing and logging scripts](https://github.com/Microsoft/busiotools/blob/master/sensors/tracing/README.md)
 - [Building a Light Testing Tool](testing-MALT-building-a-light-testing-tool.md)
+- [Light Sensor Guidance and Manual Testing](https://docs.microsoft.com/en-us/windows-hardware/design/whitepapers/integrating-ambient-light-sensors-with-computers-running-windows-10-creators-update)


### PR DESCRIPTION
Adding a link to the light sensor whitepaper since it includes testing and validation steps for light sensors.