### PR TITLE
Fixing instructions for loading symbols for MyApp

### DIFF
--- a/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
+++ b/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
@@ -229,11 +229,9 @@ For this exercise, we will assume that the built application (MyApp.exe) and the
 2.  On the **File** menu, choose **Open Executable**. In the Open Executable dialog box, navigate to C:\\MyApp\\x64\\Debug. For **File name**, enter MyApp.exe. Click **Open**.
 3.  Enter these commands:
 
-    [.sympath srv\*](https://go.microsoft.com/fwlink/p?linkid=399238)
+    .symfix
 
     .sympath+ C:\\MyApp\\x64\\Debug
-
-    [.srcpath C:\\MyApp\\MyApp](https://go.microsoft.com/fwlink/p?linkid=399395)
 
     Now WinDbg knows where to find symbols and source code for your application.
 

--- a/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
+++ b/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
@@ -222,18 +222,18 @@ void main ()
 }
 ```
 
-For this exercise, we will assume that the built application (MyApp.exe) and the symbol file (MyApp.pdb) are in C:\\MyApp\\x64\\Debug. We will also assume that the application source code is in C:\\MyApp\\MyApp.
+For this exercise, we will assume that the built application (MyApp.exe) and the symbol file (MyApp.pdb) are in C:\\MyApp\\x64\\Debug. We will also assume that the application source code is in C:\\MyApp\\MyApp and that the target machine compiled MyApp.exe.
 
 1.  Open WinDbg.
 
 2.  On the **File** menu, choose **Open Executable**. In the Open Executable dialog box, navigate to C:\\MyApp\\x64\\Debug. For **File name**, enter MyApp.exe. Click **Open**.
 3.  Enter these commands:
 
-    .symfix
+    [.symfix](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/-symfix--set-symbol-store-path-)
 
-    .sympath+ C:\\MyApp\\x64\\Debug
+    [.sympath](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/-sympath--set-symbol-path-)+ C:\\MyApp\\x64\\Debug
 
-    Now WinDbg knows where to find symbols and source code for your application.
+    Now WinDbg knows where to find symbols and source code for your application. In this case, the source code location doesn't need to be set with [.srcpath](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/-srcpath---lsrcpath--set-source-path-) because the symbols have fully qualified paths to the source files.
 
 4.  Enter these commands:
 


### PR DESCRIPTION
.symfix will reset sympath to Microsoft public symbol server and since we are debugging on the same machine that we compiled the code, setting .srcpath is unnecessary. Symbols already have hard-coded paths to source files, which will work automatically because the target and the machine that compiled the code are the same. Removing this step will not only reduce confusion, but it will reduce the potential for mistakes.