### PR TITLE
Make WdfDeviceInitSetReleaseHardwareOrderOnFailure usage more discove…

### DIFF
--- a/windows-driver-docs-pr/wdf/power-down-and-removal-sequence-for-a-bus-driver.md
+++ b/windows-driver-docs-pr/wdf/power-down-and-removal-sequence-for-a-bus-driver.md
@@ -15,6 +15,8 @@ The following figure shows the order in which the framework calls a KMDF bus dri
 
 The framework does not delete the PDO until the device is physically removed from the system. For example, if a user disables the device in Device Manager or stops it in the Safely Remove Hardware utility but does not physically remove the device, the framework retains the PDO. If the device is later re-enabled, the framework uses the same PDO and begins the startup sequence by calling the [*EvtDevicePrepareHardware*](https://msdn.microsoft.com/library/windows/hardware/ff540880) callback, as shown in [Power-Up Sequence for a Physical Device Object](power-up-sequence-for-a-bus-driver.md).
 
+**Note**: Typically, the framework calls a bus driver's EvtDeviceReleaseHardware callback function after it has called the EvtDeviceReleaseHardware function for all child devices that the driver enumerates. In the event of the parent encountering a device power-up or power-down failure, the framework might call the driver's EvtDeviceReleaseHardware before it has called the EvtDeviceReleaseHardware functions for all child devices. Consider using [WdfDeviceInitSetReleaseHardwareOrderOnFailure](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdfdevice/nf-wdfdevice-wdfdeviceinitsetreleasehardwareorderonfailure) to ensure the framework calls the bus driver's EvtDeviceReleaseHardware callback only after all child devices have been removed.
+
  
 
  


### PR DESCRIPTION
…rable for bus drivers

Make WdfDeviceInitSetReleaseHardwareOrderOnFailure usage more discoverable for bus drivers by calling it out in the power up/down sequence