### PR TITLE
adding MSDL service status + contact info

### DIFF
--- a/windows-driver-docs-pr/debugger/microsoft-public-symbols.md
+++ b/windows-driver-docs-pr/debugger/microsoft-public-symbols.md
@@ -10,6 +10,12 @@ ms.localizationpriority: medium
 # Microsoft public symbol server
 
 
+**Server Status:** No known issues :white_check_mark: <br> 
+The Microsoft public symbol server is fully operational. <br>
+Please report any known issues to [windbgfb@microsoft.com](mailto:windbgfb@microsoft.com). 
+
+---
+
 The Microsoft symbol server makes Windows debugger symbols publicly available.
 
 You can refer directly to the public symbol server in your symbol path in the following manner:


### PR DESCRIPTION
The goal here is to have a "status box" on this page to display to customers whether the public symbols server is up or not + an official avenue to report issues, which we currently don't have. The status will be edited as part of any livesite work if issues come in so will require a manual edit from our on-call folks. Historically this has only happened once every two months or so. The next step is to see if we can do any automated azure monitor piping so the status can be automatically updated. I just realized I didn't edit this with a corporate GitHub account so please let me know if I need to do so (hehua). 