### PR TITLE
Updating default option

### DIFF
--- a/windows-driver-docs-pr/network/inf-requirements-for-ndkpi.md
+++ b/windows-driver-docs-pr/network/inf-requirements-for-ndkpi.md
@@ -37,7 +37,7 @@ The INF file for a miniport driver that supports Network Direct kernel (NDK) mus
 
     ```INF
     HKR, Ndi\Params\*NetworkDirectTechnology,        ParamDesc,  0,  "NetworkDirect Technology"
-    HKR, Ndi\Params\*NetworkDirectTechnology,        Default,    0,  "0"
+    HKR, Ndi\Params\*NetworkDirectTechnology,        Default,    0,  "1"
     HKR, Ndi\Params\*NetworkDirectTechnology,        Type,       0,  "enum"
     HKR, Ndi\Params\*NetworkDirectTechnology\enum,   1,          0,  "iWARP"
     HKR, Ndi\Params\*NetworkDirectTechnology\enum,   2,          0,  "InfiniBand"


### PR DESCRIPTION
Updating to be a member of the example enumerations.  IHV must set this to the default value, where if iWARP capable, then iWARP should be the default.