### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/windows-driver-docs-pr/install/test-signing.md
+++ b/windows-driver-docs-pr/install/test-signing.md
@@ -232,7 +232,7 @@ tstamd64.cat specifies the name of the catalog file, which will be digitally-sig
     Below is the command to embed sign a kernel mode driver binary file.
 
     ```cpp
-    signtool sign  /v  /s  PrivateCertStore  /n  Contoso.com(Test)  /t http://timestamp.verisign.com/scripts/timestamp.dll   amd64\toaster.sys
+    signtool sign  /v  /s  PrivateCertStore  /n  Contoso.com(Test)  /t http://timestamp.digicert.com   amd64\toaster.sys
     ```
 
     amd64\\toaster.sys specifies the name of the kernel-mode binary file which will be embed-signed.


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.