### PR TITLE
Fix for Bug: 23484912 - Device MFT documentation mentions MFT0 instead of DMFT 

### DIFF
--- a/windows-driver-docs-pr/stream/dmft-design.md
+++ b/windows-driver-docs-pr/stream/dmft-design.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 
 # Device MFT design guide
 
-The video capture stack in Windows supports a user-mode extension in the form of MFT0. This is a per-stream extension component that IHVs supply, and the capture pipeline inserts as the first transform, post-capture. The MFT0 is fed post-processed frames from the device. Further post processing operations on the frames can be done inside MFT0. 
+The video capture stack in Windows supports a user-mode extension in the form of DMFT. This is a per-device extension component that IHVs supply, and the capture pipeline inserts as the first transform, post-capture. The DMFT receives post-processed frames from the device. Further post processing operations on the frames can be done inside the DMFT. The DMFT can receive frames from all the streams of the device and it can expose any number of output streams as per the requirement.
 
 This topic outlines the design of a device-wide extension running in user mode that can be used to perform post-processing common to all streams.
 


### PR DESCRIPTION
Removed the mentions of MFT0 and modified the description to describe the DMFT.
OS repo bug - https://microsoft.visualstudio.com/_workitems/edit/23484912?fullScreen=True
