### PR TITLE
Document executable name option in WinDbgX cmd line

### DIFF
--- a/windows-driver-docs-pr/debugger/windbg-command-line-preview.md
+++ b/windows-driver-docs-pr/debugger/windbg-command-line-preview.md
@@ -74,6 +74,7 @@ Option | Description
 |          -z *DumpFile*           |                                                                    Specifies the name of a crash dump file to debug. If the path and file name contain spaces, this must be surrounded by quotation marks.                                                                    |
 | -openPrivateDumpByHandle *Handle* |                                                                                             *Microsoft internal use only*. Specifies the handle of a crash dump file to debug.                                                                                               |
 |    -debugArch x86 -or- amd64     |                                                                                                 Override the autodetect behavior and set the target bitness for the debugger.                                                                                                 |
+|            executable            | Specifies the command line of an executable process. This is used to launch a new process and debug it. This has to be the final item on the command line. All text after the executable name is passed to the executable as its argument string.
 
 **Symbol Options**
 


### PR DESCRIPTION
`WinDbgX.exe [executable]`: launch the executable and debug it.
The description is copied from https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/windbg-command-line-options