### PR TITLE
Update process-syntax.md

### DIFF
--- a/windows-driver-docs-pr/debugger/process-syntax.md
+++ b/windows-driver-docs-pr/debugger/process-syntax.md
@@ -64,7 +64,7 @@ The current process defines the memory space and the set of threads that are use
 
 Process identifiers are used as parameters in several commands, frequently as the command prefix. Note that WinDbg and CDB can debug child processes that the original process created. WinDbg and CDB can also attach to multiple unrelated processes.
 
-An example of the |\[*Expression*\] syntax would be \[|@$t0\]. In this example, the process changes depending on the value of a user-defined pseudo-register. This syntax allows debugger scripts to programmatically select a process.
+An example of the |\[*Expression*\] syntax would be |\[@$t0\]. In this example, the process changes depending on the value of a user-defined pseudo-register. This syntax allows debugger scripts to programmatically select a process.
 
 ### <span id="controlling_processes_in_kernel_mode"></span><span id="CONTROLLING_PROCESSES_IN_KERNEL_MODE"></span>Controlling Processes in Kernel Mode
 


### PR DESCRIPTION
The example in the 'An example of the |[Expression] syntax ...' paragraph was malformed.  The pipe (|) should be outside the square brackets, not in.  That is, the example was supposed to be this:
|[@$t0]
not this:
[|@$t0]
