### PR TITLE
Clarify SDV library limitations

### DIFF
--- a/windows-driver-docs-pr/devtest/determining-if-static-driver-verifier-supports-your-driver-or-library.md
+++ b/windows-driver-docs-pr/devtest/determining-if-static-driver-verifier-supports-your-driver-or-library.md
@@ -12,12 +12,16 @@ Static Driver Verifier (SDV) fully supports WDM, KMDF, NDIS, and Storport driver
 
 ## Driver or library requirements
 
-You can run the full set of rules in the SDV analysis tool if your driver or library meets one of following conditions:
+You can run the full set of rules in the SDV analysis tool if your driver or library meets one of following conditions **and** does not link to any of the [class framework libraries listed below](#class-framework-libraries).
 
-- You have a WDM driver or library, and the driver or library does not link to a class framework (that is, a Microsoft-provided library). For more information, see [Class framework libraries](#class-framework-libraries).
+- You have a WDM driver or library.
 - You have a driver or library that links to WdfLdr.lib or WdfDriverEntry.lib.
 - You have a driver or library that links to NDIS.lib.
 - You have a driver or library that links to Storport.lib.
+
+If you have a driver that falls outside of the above conditions, SDV will consider the driver "generic" and run a limited set of checks.
+
+In addition, please note that libraries verified by SDV must be kernel-mode driver libraries, not general C or C++ libraries.  
 
 Static Driver Verifier supports a driver or library that passes those conditions even if the driver or library links to multiple [utility libraries](#utility-libraries).
 


### PR DESCRIPTION
SDV owner here.  This page states that the class framework library limitations apply only to WDM drivers, which is incorrect.  They apply to all drivers; this new language reflects that.  This change also indicates that some checks can still be performed even if the driver does not adhere to these limitations.

This change also makes explicit that SDV can only process driver libraries, not generic C/C++ libraries.