### PR TITLE
Fix command to enable testsigning

### DIFF
--- a/windows-driver-docs-pr/kernel/working-with-guid-device-reset-interface-standard.md
+++ b/windows-driver-docs-pr/kernel/working-with-guid-device-reset-interface-standard.md
@@ -133,7 +133,7 @@ The preceding command generates SSDT.aml.
 4. Enable test signing on the test system. 
 
 ```console
-bcdedit /set GUID_DEVICE_RESET_INTERFACE_STANDARD testsigning on
+bcdedit /set testsigning on
 ```
 
 5. Reboot the test system. 


### PR DESCRIPTION
The original command might have specified `{default}` which someone
might have incorrectly assumed to be a placeholder for a GUID.