### PR TITLE
Remove set from UICC_ACCESS

### DIFF
--- a/windows-driver-docs-pr/network/mb-uicc-application-and-file-system-access.md
+++ b/windows-driver-docs-pr/network/mb-uicc-application-and-file-system-access.md
@@ -268,8 +268,8 @@ This CID sends a specific command to access a UICC binary file, with structure t
 
 |  | Set | Query | Notification |
 | --- | --- | --- | --- |
-| Command | MBIM_UICC_ACCESS_BINARY | MBIM_UICC_ACCESS_BINARY | Not applicable |
-| Response | MBIM_UICC_RESPONSE | MBIM_UICC_RESPONSE | Not applicable |
+| Command | Not applicable | MBIM_UICC_ACCESS_BINARY | Not applicable |
+| Response | Not applicable | MBIM_UICC_RESPONSE | Not applicable |
 
 ### Query
 
@@ -294,7 +294,7 @@ Reads a binary file. The InformationBuffer for MBIM_COMMAND_MSG contains an MBIM
 
 ### Set
 
-Updates a transparent file. The InformationBuffer for MBIM_COMMAND_MSG contains an MBIM_UICC_ACCESS_BINARY structure. An MBIM_UICC_RESPONSE structure is returned in the InformationBuffer of MBIM_COMMAND_DONE.
+Not applicable.
 
 ### Response
 
@@ -336,8 +336,8 @@ This CID sends a specific command to access a UICC linear fixed or cyclic file, 
 
 |  | Set | Query | Notification |
 | --- | --- | --- | --- |
-| Command | MBIM_UICC_ACCESS_RECORD | MBIM_UICC_ACCESS_RECORD | Not applicable |
-| Response | MBIM_UICC_RESPONSE | MBIM_UICC_RESPONSE | Not applicable |
+| Command | Not applicable | MBIM_UICC_ACCESS_RECORD | Not applicable |
+| Response | Not applicable | MBIM_UICC_RESPONSE | Not applicable |
 
 ### Query
 
@@ -361,7 +361,7 @@ Reads contents of a record. The InformationBuffer for MBIM_COMMAND_MSG contains 
 
 ### Set
 
-Updates a linear fixed or cyclic file. The InformationBuffer for MBIM_COMMAND_MSG contains the following MBIM_UICC_ACCESS_RECORD structure. MBIM_UICC_RESPONSE is returned in the InformationBuffer of MBIM_COMMAND_DONE.
+Not applicable.
 
 ### Response
 

--- a/windows-driver-docs-pr/network/oid-wwan-uicc-access-binary.md
+++ b/windows-driver-docs-pr/network/oid-wwan-uicc-access-binary.md
@@ -15,8 +15,6 @@ OID_WWAN_UICC_ACCESS_BINARY accesses a UICC binary file, the structure type of w
 
 Query requests read a binary file. Query payloads contain an [**NDIS_WWAN_UICC_ACCESS_BINARY**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_access_binary) structure specifying information about the file to read. Miniport drivers must process Query requests asynchronously, initially returning NDIS_STATUS_INDICATION_REQUIRED to the original request before later sending an [NDIS_STATUS_WWAN_UICC_BINARY_RESPONSE](ndis-status-wwan-uicc-binary-response.md) status notification containing an [**NDIS_WWAN_UICC_RESPONSE**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_response) structure that describes the UICC's response. 
 
-Set requests update a binary file. Set payloads contain an [**NDIS_WWAN_UICC_ACCESS_BINARY**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_access_binary) structure specifying information about the file to which to write. Miniport drivers must process Set requests asynchronously, initially returning NDIS_STATUS_INDICATION_REQUIRED to the original request before later sending an [NDIS_STATUS_WWAN_UICC_BINARY_RESPONSE](ndis-status-wwan-uicc-binary-response.md) status notification containing an [**NDIS_WWAN_UICC_RESPONSE**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_response) structure that describes the UICC's response. 
-
 ## Remarks
 
 For more information about usage of this OID, see [MB UICC application and file system access](mb-uicc-application-and-file-system-access.md).

--- a/windows-driver-docs-pr/network/oid-wwan-uicc-access-record.md
+++ b/windows-driver-docs-pr/network/oid-wwan-uicc-access-record.md
@@ -15,8 +15,6 @@ OID_WWAN_UICC_ACCESS_RECORD accesses a UICC linear fixed or cyclic file, the str
 
 Query requests read the contents of a record. Query payloads contain an [**NDIS_WWAN_UICC_ACCESS_RECORD**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_access_record) structure specifying information about the file to read. Miniport drivers must process Query requests asynchronously, initially returning NDIS_STATUS_INDICATION_REQUIRED to the original request before later sending an [NDIS_STATUS_WWAN_UICC_RECORD_RESPONSE](ndis-status-wwan-uicc-record-response.md) status notification containing an [**NDIS_WWAN_UICC_RESPONSE**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_response) structure that describes the UICC's response. 
 
-Set requests update a linear fixed or cyclic file. Set payloads contain an [**NDIS_WWAN_UICC_ACCESS_RECORD**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_access_record) structure specifying information about the file to which to write. Miniport drivers must process Set requests asynchronously, initially returning NDIS_STATUS_INDICATION_REQUIRED to the original request before later sending an [NDIS_STATUS_WWAN_UICC_RECORD_RESPONSE](ndis-status-wwan-uicc-record-response.md) status notification containing an [**NDIS_WWAN_UICC_RESPONSE**](https://docs.microsoft.com/windows-hardware/drivers/ddi/ndiswwan/ns-ndiswwan-_ndis_wwan_uicc_response) structure that describes the UICC's response. 
-
 ## Remarks
 
 For more information about usage of this OID, see [MB UICC application and file system access](mb-uicc-application-and-file-system-access.md).


### PR DESCRIPTION
Set is not yet supported for UICC_ACCESS_BINARY and UICC_ACCESS_RECORD in the class driver, therefore must be removed from the documentation.