### PR TITLE
replaced wrong link to new link

### DIFF
--- a/windows-driver-docs-pr/devtest/editing-boot-options.md
+++ b/windows-driver-docs-pr/devtest/editing-boot-options.md
@@ -14,13 +14,9 @@ ms.localizationpriority: medium
 
 # Editing Boot Options
 
+This section is a practical guide to editing the boot options on a computer running Windows Server 2008, Windows Server 2012, or Windows 7 or later. It suggests a step-by-step procedure for customizing the basic elements of boot options.
 
-## <span id="ddk_editing_boot_options_tools"></span><span id="DDK_EDITING_BOOT_OPTIONS_TOOLS"></span>
-
-
-This section is a practical guide to editing the boot options on a computer running Windows 10, Windows 8, Windows Server 2012, Windows 7, or Windows Server 2008. It suggests a step-by-step procedure for customizing the basic elements of boot options.
-
-This section describes a method of using BCDEdit, a tool included with the operating system. For information about BCDEdit command syntax, type **bcdedit /?** or **bcdedit /? TOPICS** in a Command Prompt window. See [BCD Boot Options Reference](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcd-boot-options-reference) for more information.
+This section describes a method of using BCDEdit, a tool included with the operating system. For information about BCDEdit command syntax, type **bcdedit /?** or **bcdedit /? TOPICS** in a Command Prompt window. See [BCD Boot Options Reference](https://docs.microsoft.com/windows-hardware/drivers/devtest/bcd-boot-options-reference) for more information.
 
 > [!NOTE]
 > Before setting BCDEdit options you might need to disable or suspend BitLocker and Secure Boot on the computer.
@@ -42,7 +38,7 @@ Then, to make testing quicker and easier:
 -  [Change the boot menu time-out](changing-the-boot-menu-time-out.md). You can shorten the boot menu time-out so that Windows boots quickly. Or, lengthen the boot menu time-out so that you have ample time to select the preferred boot entry.
 
 ## Related Topics 
- [BCDEdit Command-Line Options](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options)
+ [BCDEdit Command-Line Options](https://docs.microsoft.com/windows-hardware/manufacture/desktop/bcdedit-command-line-options)
 
 > [!CAUTION]
 > Administrative privileges are required to use BCDEdit to modify BCD. Changing some boot entry options using the **BCDEdit /set** command could render your computer inoperable. As an alternative, use the System Configuration utility (MSConfig.exe) to change boot settings.

--- a/windows-driver-docs-pr/devtest/editing-boot-options.md
+++ b/windows-driver-docs-pr/devtest/editing-boot-options.md
@@ -41,7 +41,7 @@ Then, to make testing quicker and easier:
 
 -  [Change the boot menu time-out](changing-the-boot-menu-time-out.md). You can shorten the boot menu time-out so that Windows boots quickly. Or, lengthen the boot menu time-out so that you have ample time to select the preferred boot entry.
 
-# Related Topics 
+## Related Topics 
  [BCDEdit Command-Line Options](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options)
 
 > [!CAUTION]

--- a/windows-driver-docs-pr/devtest/editing-boot-options.md
+++ b/windows-driver-docs-pr/devtest/editing-boot-options.md
@@ -20,7 +20,7 @@ ms.localizationpriority: medium
 
 This section is a practical guide to editing the boot options on a computer running Windows 10, Windows 8, Windows Server 2012, Windows 7, or Windows Server 2008. It suggests a step-by-step procedure for customizing the basic elements of boot options.
 
-This section describes a method of using BCDEdit, a tool included with the operating system. For information about BCDEdit command syntax, type **bcdedit /?** or **bcdedit /? TOPICS** in a Command Prompt window. See [BCD Boot Options Reference](https://docs.microsoft.com/windows-hardware/drivers/ddi/index) for more information.
+This section describes a method of using BCDEdit, a tool included with the operating system. For information about BCDEdit command syntax, type **bcdedit /?** or **bcdedit /? TOPICS** in a Command Prompt window. See [BCD Boot Options Reference](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcd-boot-options-reference) for more information.
 
 > [!NOTE]
 > Before setting BCDEdit options you might need to disable or suspend BitLocker and Secure Boot on the computer.
@@ -40,6 +40,9 @@ Then, to make testing quicker and easier:
 - [Make the new boot entry the default entry](changing-the-default-boot-entry.md).
 
 -  [Change the boot menu time-out](changing-the-boot-menu-time-out.md). You can shorten the boot menu time-out so that Windows boots quickly. Or, lengthen the boot menu time-out so that you have ample time to select the preferred boot entry.
+
+# Related Topics 
+ [BCDEdit Command-Line Options](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options)
 
 > [!CAUTION]
 > Administrative privileges are required to use BCDEdit to modify BCD. Changing some boot entry options using the **BCDEdit /set** command could render your computer inoperable. As an alternative, use the System Configuration utility (MSConfig.exe) to change boot settings.


### PR DESCRIPTION
As per the user issue # 1903
 i have replaced the wrong link
**https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/index**

to new correct link
**https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcd-boot-options-reference**

also added a related  topic link
**https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options**