### PR TITLE
replaced invalid links to mew links

### DIFF
--- a/windows-driver-docs-pr/print/port-monitor-server-dll-functions.md
+++ b/windows-driver-docs-pr/print/port-monitor-server-dll-functions.md
@@ -34,7 +34,7 @@ The following table lists the functions that a port monitor server DLL must defi
 <td><p>DLL entry point, typically called <strong>DllMain</strong>, which is described in the Microsoft Windows SDK documentation.</p></td>
 </tr>
 <tr class="even">
-<td><p><a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport" data-raw-source="[&lt;strong&gt;ClosePort&lt;/strong&gt;](https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport)"><strong>ClosePort</strong></a></p></td>
+<td><p><a href="https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport" data-raw-source="[&lt;strong&gt;ClosePort&lt;/strong&gt;](https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport)"><strong>ClosePort</strong></a></p></td>
 <td><p>Closes a port if there are no printers connected to it.</p></td>
 </tr>
 <tr class="odd">
@@ -46,7 +46,7 @@ The following table lists the functions that a port monitor server DLL must defi
 <td><p>Enumerates the ports available for printing on a server.</p></td>
 </tr>
 <tr class="odd">
-<td><p><a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2" data-raw-source="[&lt;strong&gt;InitializePrintMonitor2&lt;/strong&gt;](https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2)"><strong>InitializePrintMonitor2</strong></a></p></td>
+<td><p><a href="https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2" data-raw-source="[&lt;strong&gt;InitializePrintMonitor2&lt;/strong&gt;](https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2)"><strong>InitializePrintMonitor2</strong></a></p></td>
 <td><p>Initializes the print monitor and returns an instance handle.</p></td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
as per the user reported issue #1926 

i have replaced two invalid links by new links

invalid link
https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport

replaced link
https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-closeport

invalid link
https://docs.microsoft.com/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2

replaced link
https://docs.microsoft.com/en-in/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitor2

Thanking you