### PR TITLE
Clarity fixes for KDNET docs

### DIFF
--- a/windows-driver-docs-pr/debugger/setting-up-a-network-debugging-connection-automatically.md
+++ b/windows-driver-docs-pr/debugger/setting-up-a-network-debugging-connection-automatically.md
@@ -59,25 +59,25 @@ Use the kdnet.exe utility to automatically configure the  debugger settings on t
 4. On the target computer, create a C:\KDNET directory and copy the *kdnet.exe* and *VerifiedNICList.xml* files to that directory.
 
    > [!IMPORTANT]
-   > Before using kdnet to change boot information you may need to temporarily suspend Windows security features such as BitLocker and Secure Boot on the test PC.
+   > Before using kdnet.exe to change boot information you may need to temporarily suspend Windows security features such as BitLocker and Secure Boot on the test PC.
    > Re-enable these security features when testing is complete and appropriately manage the test PC, when the security features are disabled.
 
 
 5. On the target computer, open a Command Prompt window as Administrator. Enter this command to verify that the target computer has a supported network adapter.
 
    ```console
-   C:\KDNET>kdnet
+   C:\KDNET>kdnet.exe
    Network debugging is supported on the following NICs:
    busparams=1.0.0, Broadcom NetXtreme Gigabit Ethernet, Plugged in.  
    This Microsoft hypervisor supports using KDNET in guest VMs.
    ```
 
-6. As the output from kdnet indicates that network adapter on the target is supported, we can proceed.
+6. As the output from kdnet.exe indicates that network adapter on the target is supported, we can proceed.
 
-7. Type this command to set the IP address of the host system and generated a unique connection key. Use the IP address or the name of the host system. Pick a unique port address for each target/host pair that you work with, with in the recommended range of 50000-50039.
+7. Type this command to set the IP address of the host system and generated a unique connection key. Use the IP address or the name of the host system. Pick a unique port address for each target/host pair that you work with, within the recommended range of 50000-50039.
 
    ```console
-   C:\>kdnet <HostComputerIPAddress> <YourDebugPort> 
+   C:\>kdnet.exe <HostComputerIPAddress> <YourDebugPort> 
    
    Enabling network debugging on Intel(R) 82577LM Gigabit Network Connection.
    Key=2steg4fzbj2sz.23418vzkd4ko3.1g34ou07z4pev.1sp3yo9yz874p
@@ -90,7 +90,7 @@ Use the kdnet.exe utility to automatically configure the  debugger settings on t
 
 On the host computer, open WinDbg. On the **File** menu, choose **Kernel Debug**. In the Kernel Debugging dialog box, open the **Net** tab. Paste in your port number and key that you saved to in the notepad .txt file earlier. Click **OK**.
 
-You can also start a WinDbg session by opening a Command Prompt window and entering the following command, where <YourPort> is the port you selected above, and <YourKey> is the key that was returned by kdnet above. Paste in the key in that you saved to in the notepad .txt file earlier.
+You can also start a WinDbg session by opening a Command Prompt window and entering the following command, where <YourPort> is the port you selected above, and <YourKey> is the key that was returned by kdnet.exe above. Paste in the key in that you saved to in the notepad .txt file earlier.
 
    ```console
   windbg -k net:port=<YourDebugPort>,key=<YourKey> 
@@ -113,7 +113,7 @@ At this point the debugger will be waiting for the target to reconnect and text 
 
 ## <span id="Restarting_Target"></span><span id="restarting_target"></span><span id="RESTARTING_TARGET"></span> Restarting the Target PC
 
-Once the debugger is connected, reboot the target computer. One way to do restart the PC, is to use this command from an administrator's command prompt.
+Once the debugger is at the "Waiting to reconnect..." stage, reboot the target computer. One way to do restart the PC, is to use this command from an administrator's command prompt.
 
    ```console
    shutdown -r -t 0 


### PR DESCRIPTION
Adding some clarity to disambiguate "kdnet" the protocol and "kdnet.exe" the tool, as well as cleaning up the directions on when to restart the target.