### PR TITLE
removed the sentence

### DIFF
--- a/windows-driver-docs-pr/debugger/the-dbgeng-h-header-file.md
+++ b/windows-driver-docs-pr/debugger/the-dbgeng-h-header-file.md
@@ -15,9 +15,9 @@ ms.localizationpriority: medium
 
 Routines in the dbgeng.h header file are used to write DbgEng extensions.
 
-For details on the dbgeng.h header file and information about how to write debugger extensions, see
+For details on the dbgeng.h header file and information about how to write debugger extensions,
 
-For information about how to write debugger extensions, see [Writing DbgEng Extensions](writing-dbgeng-extensions.md) and [Using the Debugger Engine API](using-the-debugger-engine-api.md).
+see [Writing DbgEng Extensions](writing-dbgeng-extensions.md) and [Using the Debugger Engine API](using-the-debugger-engine-api.md).
 
  
 


### PR DESCRIPTION
as per the user report #2049 .  i removed the following sentence 

**For information about how to write debugger extensions,**