### PR TITLE
Multiply Assign operator missing * and formatting

### DIFF
--- a/windows-driver-docs-pr/debugger/c---numbers-and-operators.md
+++ b/windows-driver-docs-pr/debugger/c---numbers-and-operators.md
@@ -190,11 +190,12 @@ You can use the following operators. The operators in each cell take precedence 
 <td align="left"><p>Logical OR</p></td>
 </tr>
 <tr class="even">
-<td align="left"><p><em>LValue</em> <strong>=</strong><em>Value</em></p>
-<p><em>LValue</em> <strong></em>=</strong> <em>Value</em></p>
+<td align="left">
+<p><em>LValue</em> <strong>=</strong> <em>Value</em></p>
+<p><em>LValue</em> <strong>*=</strong> <em>Value</em></p>
 <p><em>LValue</em> <strong>/=</strong> <em>Value</em></p>
-<p><em>LValue</em> <strong>%=</strong><em>Value</em></p>
-<p><em>LValue</em> <strong>+=</strong><em>Value</em></p>
+<p><em>LValue</em> <strong>%=</strong> <em>Value</em></p>
+<p><em>LValue</em> <strong>+=</strong> <em>Value</em></p>
 <p><em>LValue</em> <strong>-=</strong> <em>Value</em></p>
 <p><em>LValue</em> <strong>&lt;&lt;=</strong> <em>Value</em></p>
 <p><em>LValue</em> <strong>&gt;&gt;=</strong> <em>Value</em></p>


### PR DESCRIPTION
The multiply assign was missing the `*` and there were other minor formatting details on that area.