### PR TITLE
added correct  website link for MBS

### DIFF
--- a/windows-driver-docs-pr/mobilebroadband/review-the-hotspot-authentication-sample.md
+++ b/windows-driver-docs-pr/mobilebroadband/review-the-hotspot-authentication-sample.md
@@ -11,7 +11,7 @@ ms.localizationpriority: medium
 
 The [Hotspot Authentication Sample](https://docs.microsoft.com/samples/microsoft/windows-universal-samples/hotspotauthentication/) demonstrates the application of a provisioning file and how it handles a hotspot authentication event. This sample does not run with privileged APIs; it demonstrates the application of signed provisioning metadata.
 
-For an example of how to use unsigned provisioning metadata together with privilege APIs, see the [Mobile Broadband Provisioning sample](https://go.microsoft.com/fwlink/p/?linkid=256401).
+For an example of how to use unsigned provisioning metadata together with privilege APIs, see the [Mobile Broadband Provisioning sample](https://docs.microsoft.com/samples/microsoft/windows-universal-samples/mobilebroadband/).
 
 ## <span id="related_topics"></span>Related topics
 


### PR DESCRIPTION
I checked the hyperlink of the mobile broadband sample link, and I found it that the landing page is a complete portal of all samples.
so I added the correct location of the link.

**https://docs.microsoft.com/samples/microsoft/windows-universal-samples/mobilebroadband/**