### PR TITLE
Update Device Orientation Notes

### DIFF
--- a/windows-driver-docs-pr/stream/camera-device-orientation.md
+++ b/windows-driver-docs-pr/stream/camera-device-orientation.md
@@ -95,7 +95,7 @@ No matter which value **NativeOrientation** returns, the logical display scannin
 
 Note that, unlike camera, the **NativeOrientation** property is not based on ACPI and thus does not have a \_PLD structure. This is true even if a display is statically mounted to a device.
 
-When mounting on a Portrait Primary device, Camera Drivers must be aware that most application will treat the device as outputting a Landscape camera output buffer regardless of the actual camera output buffer orientation. Because of this, Camera Drivers are recommended to output a camera buffer that has a 90 degree orientation offset from the NativeOrientation Portrait when on a Portrait Primary device. This will then allow applications that are performing this additional rotation on Portrait devices to correct the rotation to the expected Orientation.
+When mounting on a Portrait Primary device, camera drivers must be aware that most applications will treat the device as outputting a landscape camera output buffer regardless of the actual camera output buffer orientation. Because of this, we recommend that camera drivers output a camera buffer that has a 90 degree orientation offset from the NativeOrientation Portrait when on a Portrait Primary device. This will then allow applications that are performing this additional rotation on portrait devices to correct the rotation to the expected orientation.
 
 ## Offset Mounting
 

--- a/windows-driver-docs-pr/stream/camera-device-orientation.md
+++ b/windows-driver-docs-pr/stream/camera-device-orientation.md
@@ -95,6 +95,8 @@ No matter which value **NativeOrientation** returns, the logical display scannin
 
 Note that, unlike camera, the **NativeOrientation** property is not based on ACPI and thus does not have a \_PLD structure. This is true even if a display is statically mounted to a device.
 
+When mounting on a Portrait Primary device, Camera Drivers must be aware that most application will treat the device as outputting a Landscape camera output buffer regardless of the actual camera output buffer orientation. Because of this, Camera Drivers are recommended to output a camera buffer that has a 90 degree orientation offset from the NativeOrientation Portrait when on a Portrait Primary device. This will then allow applications that are performing this additional rotation on Portrait devices to correct the rotation to the expected Orientation.
+
 ## Offset Mounting
 
 IHV/OEMs are strongly encouraged to avoid mounting the sensor in a non-0 degree offset to maintain app compatibility. Many existing and legacy apps do not know to look for the ACPI’s PLD table, nor will attempt to correct the non-0 degree offset. Consequently, for such apps the resulting video will be rendered incorrectly.


### PR DESCRIPTION
The Portrait first devices are being counter rotated by applications. We need to inform driver developers to take this into account.