### PR TITLE
Fix a broken link

### DIFF
--- a/windows-driver-docs-pr/network/ndis-interface-information.md
+++ b/windows-driver-docs-pr/network/ndis-interface-information.md
@@ -25,7 +25,7 @@ NDIS provides enhanced support for Management Instrumentation (WMI). For more in
 ## Related topics
 
 
-[**NDIS\_INTERFACE\_INFORMATION**](https://docs.microsoft.com/windows/desktop/api/ifdef/ns-ifdef-_ndis_interface_information)
+[**NDIS\_INTERFACE\_INFORMATION**](https://docs.microsoft.com/windows/desktop/api/ifdef/ns-ifdef-ndis_interface_information)
 
  
 


### PR DESCRIPTION
The URL to which NDIS_INTERFACE_INFORMATION was linked had an extra _ in it; that broke the link.