### PR TITLE
removing deprecated verifier checks

### DIFF
--- a/windows-driver-docs-pr/devtest/verifier-command-line.md
+++ b/windows-driver-docs-pr/devtest/verifier-command-line.md
@@ -16,6 +16,13 @@ ms.localizationpriority: medium
 
 # Driver Verifier Command Syntax
 
+[!NOTE]
+> Starting in preview versions of Windows 10 builds 19600 and above, the following Verifier settings have been deprecated:
+> -	0x00800000 (bit 23) - Kernel synchronization delay fuzzing
+> - 0x00080000 (bit 19) - DDI compliance checking (additional)
+> - 0x00040000 (bit 18) - Systematic low resources simulation
+> - 0x00008000 (bit 15) - Power framework delay fuzzing
+> If this is a concern for your Verifier scenario, please reach out to wdkfeedback@microsoft.com
 
 The following syntax is used when running the Verifier utility in a Command Prompt window.
 
@@ -368,12 +375,6 @@ Activates the specified options after the next reboot. In Windows 2000, this num
 <td align="left"></td>
 <td align="left"><p><a href="invariant-mdl-checking-for-driver.md" data-raw-source="[Invariant MDL Checking for Driver](invariant-mdl-checking-for-driver.md)">Invariant MDL Checking for Driver</a> (Starting with Windows 8)</p></td>
 </tr>
-<tr class="odd">
-<td align="left"><p>32768</p></td>
-<td align="left"><p>0x8000 (bit 15)</p></td>
-<td align="left"></td>
-<td align="left"><p><a href="concurrency-stress-test.md" data-raw-source="[Power Framework Delay Fuzzing](concurrency-stress-test.md)">Power Framework Delay Fuzzing</a> (Starting with Windows 8)</p></td>
-</tr>
 <tr class="even">
 <td align="left"><p>65536</p></td>
 <td align="left"><p>0x10000 (bit 16)</p></td>
@@ -387,28 +388,10 @@ Activates the specified options after the next reboot. In Windows 2000, this num
 <td align="left"><p><a href="ddi-compliance-checking.md" data-raw-source="[DDI compliance checking](ddi-compliance-checking.md)">DDI compliance checking</a> (Starting with Windows 8)</p></td>
 </tr>
 <tr class="even">
-<td align="left"><p>262144</p></td>
-<td align="left"><p>0x40000 (bit 18)</p></td>
-<td align="left"></td>
-<td align="left"><p><a href="systematic-low-resource-simulation.md" data-raw-source="[Systematic low resources simulation](systematic-low-resource-simulation.md)">Systematic low resources simulation</a> (Starting with Windows 8.1)</p></td>
-</tr>
-<tr class="odd">
-<td align="left"><p>524288</p></td>
-<td align="left"><p>0x80000 (bit 19)</p></td>
-<td align="left"></td>
-<td align="left"><p><a href="ddi-compliance-checking.md#ddi_compliance_checking_additional" data-raw-source="[DDI compliance checking (additional)](ddi-compliance-checking.md#ddi_compliance_checking_additional)">DDI compliance checking (additional)</a> (Starting with Windows 8.1)</p></td>
-</tr>
-<tr class="even">
 <td align="left"><p>2097152</p></td>
 <td align="left"><p>0x200000 (bit 21)</p></td>
 <td align="left"></td>
 <td align="left"><p><a href="ndis-wifi-verification.md" data-raw-source="[NDIS/WIFI verification](ndis-wifi-verification.md)">NDIS/WIFI verification</a> (Starting with Windows 8.1)</p></td>
-</tr>
-<tr class="odd">
-<td align="left"><p>8388608</p></td>
-<td align="left"><p>0x800000 (bit 23)</p></td>
-<td align="left"></td>
-<td align="left"><p><a href="kernel-synchronization-delay-fuzzing.md" data-raw-source="[Kernel synchronization delay fuzzing](kernel-synchronization-delay-fuzzing.md)">Kernel synchronization delay fuzzing</a> (Starting with Windows 8.1)</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>16777216</p></td>


### PR DESCRIPTION
need to edit the right minbuild and review the page once a preview gets generated