### PR TITLE
Updated Hyperlinks and Markdown Formatting

### DIFF
--- a/windows-driver-docs-pr/devtest/pnputil.md
+++ b/windows-driver-docs-pr/devtest/pnputil.md
@@ -19,7 +19,9 @@ PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform 
 
 -   Enumerates the driver packages that are currently in the driver store. Only driver packages that are not in-box packages are listed. An *in-box* driver package is one which is included in the default installation of Windows or its service packs.
 
-See [PnP Command Syntax](https://review.docs.microsoft.com/en-us/windows-hardware/drivers/devtest/pnputil-command-syntax) for a list of all supported actions.
+See [PnPUtil Command Syntax](pnputil-command-syntax.md) for a list of all supported actions.
+
+
 
 <table>
 <colgroup>

--- a/windows-driver-docs-pr/devtest/pnputil.md
+++ b/windows-driver-docs-pr/devtest/pnputil.md
@@ -21,47 +21,18 @@ PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform 
 
 See [PnPUtil Command Syntax](pnputil-command-syntax.md) for a list of all supported actions.
 
+**Where can I download PnPUtil?**
 
+PnPUtil (PnPUtil.exe) is included in every version of Windows, starting with Windows Vista (in the `%windir%\system32` directory). There isn't a separate PnPUtil download package.
 
-<table>
-<colgroup>
-<col width="100%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th align="left">Where can I download PnPUtil?</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td align="left"><p>PnPUtil (PnPUtil.exe) is included in every version of Windows, starting with Windows Vista (in the %windir%\system32 directory). There isn't a separate PnPUtil download package.</p>
-<ul>
-<li>Open a <strong>Command Prompt</strong> window (<strong>Run as administrator</strong>).</li>
-<li>Type <strong>pnputil /?</strong> to view command options. See <a href="pnputil-command-syntax.md" data-raw-source="[&lt;strong&gt;PnPUtil Command Syntax&lt;/strong&gt;](pnputil-command-syntax.md)"><strong>PnPUtil Command Syntax</strong></a> for more information.</li>
-</ul>
-<div class="alert">
-<strong>Note</strong>  PnPUtil is supported on Windows Vista and later versions of Windows. PnPUtil is not available for Windows XP, however, you can use the <a href="https://docs.microsoft.com/windows-hardware/drivers/install/difx-guidelines" data-raw-source="[Driver Install Frameworks (DIFx)](https://docs.microsoft.com/windows-hardware/drivers/install/difx-guidelines)">Driver Install Frameworks (DIFx)</a> tools to create and customize the installation of driver packages.
-</div>
-<div>
- 
-</div></td>
-</tr>
-</tbody>
-</table>
+- Open a **Command Prompt** window (**Run as administrator**).
+- Type `pnputil /?` to view command options. See [**PnPUtil Command Syntax**](pnputil-command-syntax.md) for more information.
 
- 
+> [!NOTE]
+> PnPUtil is supported on Windows Vista and later versions of Windows. PnPUtil is not available for Windows XP, however, you can use the [Driver Install Frameworks (DIFx)](https://docs.microsoft.com/windows-hardware/drivers/install/difx-guidelines) tools to create and customize the installation of driver packages.
 
 This section includes the following:
 
 [PnPUtil Command Syntax](pnputil-command-syntax.md)
 
 [PnPUtil Examples](pnputil-examples.md)
-
- 
-
- 
-
-
-
-
-

--- a/windows-driver-docs-pr/devtest/pnputil.md
+++ b/windows-driver-docs-pr/devtest/pnputil.md
@@ -9,9 +9,9 @@ ms.localizationpriority: medium
 # PnPUtil
 
 
-PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform actions on [driver packages](https://docs.microsoft.com/windows-hardware/drivers/install/driver-packages).  Some examples include:
+PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform actions on [driver packages](../install/driver-packages.md).  Some examples include:
 
--   Adds a driver package to the [driver store](https://docs.microsoft.com/windows-hardware/drivers/install/driver-store).
+-   Adds a driver package to the [driver store](../install/driver-store.md).
 
 -   Installs a driver package on the computer.
 

--- a/windows-driver-docs-pr/devtest/pnputil.md
+++ b/windows-driver-docs-pr/devtest/pnputil.md
@@ -8,7 +8,6 @@ ms.localizationpriority: medium
 
 # PnPUtil
 
-
 PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform actions on [driver packages](../install/driver-packages.md).  Some examples include:
 
 -   Adds a driver package to the [driver store](../install/driver-store.md).
@@ -30,9 +29,3 @@ PnPUtil (PnPUtil.exe) is included in every version of Windows, starting with Win
 
 > [!NOTE]
 > PnPUtil is supported on Windows Vista and later versions of Windows. PnPUtil is not available for Windows XP, however, you can use the [Driver Install Frameworks (DIFx)](https://docs.microsoft.com/windows-hardware/drivers/install/difx-guidelines) tools to create and customize the installation of driver packages.
-
-This section includes the following:
-
-[PnPUtil Command Syntax](pnputil-command-syntax.md)
-
-[PnPUtil Examples](pnputil-examples.md)

--- a/windows-driver-docs-pr/devtest/pnputil.md
+++ b/windows-driver-docs-pr/devtest/pnputil.md
@@ -10,22 +10,20 @@ ms.localizationpriority: medium
 
 PnPUtil (PnPUtil.exe) is a command line tool that lets an administrator perform actions on [driver packages](../install/driver-packages.md).  Some examples include:
 
--   Adds a driver package to the [driver store](../install/driver-store.md).
+- Adds a driver package to the [driver store](../install/driver-store.md).
 
--   Installs a driver package on the computer.
+- Installs a driver package on the computer.
 
--   Deletes a driver package from the driver store.
+- Deletes a driver package from the driver store.
 
--   Enumerates the driver packages that are currently in the driver store. Only driver packages that are not in-box packages are listed. An *in-box* driver package is one which is included in the default installation of Windows or its service packs.
+- Enumerates the driver packages that are currently in the driver store. Only driver packages that are not in-box packages are listed. An *in-box* driver package is one which is included in the default installation of Windows or its service packs.
 
-See [PnPUtil Command Syntax](pnputil-command-syntax.md) for a list of all supported actions.
+## Where can I download PnPUtil?
 
-**Where can I download PnPUtil?**
-
-PnPUtil (PnPUtil.exe) is included in every version of Windows, starting with Windows Vista (in the `%windir%\system32` directory). There isn't a separate PnPUtil download package.
+PnPUtil is included in every version of Windows, starting with Windows Vista (in the `%windir%\system32` directory). There isn't a separate PnPUtil download package.
 
 - Open a **Command Prompt** window (**Run as administrator**).
 - Type `pnputil /?` to view command options. See [**PnPUtil Command Syntax**](pnputil-command-syntax.md) for more information.
 
 > [!NOTE]
-> PnPUtil is supported on Windows Vista and later versions of Windows. PnPUtil is not available for Windows XP, however, you can use the [Driver Install Frameworks (DIFx)](https://docs.microsoft.com/windows-hardware/drivers/install/difx-guidelines) tools to create and customize the installation of driver packages.
+> PnPUtil is supported on Windows Vista and later versions of Windows. PnPUtil is not available for Windows XP, however, you can use the [Driver Install Frameworks (DIFx)](../install/difx-guidelines.md) tools to create and customize the installation of driver packages.


### PR DESCRIPTION
The main purpose for modifying this file was to fix a broken hyperlink to the [PnPUtil Command Syntax](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/pnputil-command-syntax) page. By the end though, I had removed that link entirely because while this is a small article, that article was linked three times, which felt excessive.

Additionally, I found that section at the bottom on how download the utility was an HTML table. I replaced this with standard Markdown for consistency and future supportability.