### PR TITLE
Changed wording from 'slave' to 'subordinate'

### DIFF
--- a/windows-driver-docs-pr/hid/architecture-and-overview.md
+++ b/windows-driver-docs-pr/hid/architecture-and-overview.md
@@ -38,7 +38,7 @@ The I²C controller driver exposes a Serial Peripheral Bus (SPB) IOCTL interface
 ## The GPIO Controller Driver
 
 
-The General Purpose Input/Output (GPIO) controller delivers interrupts from the device over GPIO. This is often a simple slave component that uses GPIO pins to signal Windows of new data or other events. GPIO can also control the device by approaches other than the I²C channel.
+The General Purpose Input/Output (GPIO) controller delivers interrupts from the device over GPIO. This is often a simple subordinate component that uses GPIO pins to signal Windows of new data or other events. GPIO can also control the device by approaches other than the I²C channel.
 
 ## The Resource Hub
 


### PR DESCRIPTION
The change I made edits the word 'slave' to 'subordinate' to be in line with Microsoft's Style Guide for Bias-Free Communications https://github.com/MicrosoftDocs/microsoft-style-guide/blob/master/styleguide/bias-free-communication.md.