### PR TITLE
Convert DBG2 table into Markdown from Word document and update to latest version

### DIFF
--- a/windows-driver-docs-pr/bringup/acpi-debug-port-table.md
+++ b/windows-driver-docs-pr/bringup/acpi-debug-port-table.md
@@ -109,7 +109,7 @@ Table 1 defines the fields in DBG2.
 |          |          | 0x0011      | SDM845 with clock rate of 1.8432 MHz |
 |          |          | 0x0012      | 16550-compatible with parameters defined in Generic Address Structure |
 |          |          | 0x0013      | SDM845 with clock rate of 7.372 MHz |
-|          |          | 0x0014 - 0xFFFF | Reserved (For Future Use) |
+|          |          | 0x0014 – 0xFFFF | Reserved (For Future Use) |
 | 1394     | 0x8001   | 0x0000      | IEEE1394 Standard Host Controller Interface |
 |          |          | 0x0001 – 0xFFFF | Reserved (For Future Use) |
 | USB      | 0x8002   | 0x0000      | XHCI-compliant controller with debug interface |

--- a/windows-driver-docs-pr/bringup/acpi-debug-port-table.md
+++ b/windows-driver-docs-pr/bringup/acpi-debug-port-table.md
@@ -1,0 +1,135 @@
+---
+title: Debug Port Table 2 (DBG2)
+description: The Debug Port ACPI Table is used in platform firmware to describe the debug ports available on the system.
+ms.assetid:
+keywords:
+- DBG2
+- DBGP
+- KDCOM
+- Serial
+- UART
+ms.date: 09/01/2020
+---
+
+# Microsoft Debug Port Table 2 (DBG2)
+
+This specification defines the format of the Debug Port Table 2 (DBG2), used in platform firmware to describe the debug ports available on the system.
+This information applies to the following operating systems: Windows 8 and newer.
+
+References and resources discussed here are listed at the end of this paper.
+
+>Patent Notice:
+>Microsoft is making certain patent rights available for implementations of this specification under two options:
+>
+>1. Microsoft’s Community Promise, available at <https://www.microsoft.com/openspecifications/en/us/programs/community-promise/default.aspx>; or
+>2. The Open Web Foundation Final Specification Agreement Version 1.0 ("OWF 1.0") as of October 1, 2012, available at [http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0/](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0).
+
+## Document History
+
+| **Date** | **Change** |
+|----------|------------|
+| November 29, 2011 | First publication. |
+| May 22, 2012 | Updates to Table 3 per final supported platforms for Windows 8. |
+| August 10, 2015 | Updated patent notice. |
+| October 6, 2015 | Added new serial debugging subtypes (ARM SBSA UART, ARM DCC) |
+| December 10, 2015 | Added new serial debugging subtype (BCM2835) |
+| May 31, 2017 | Added new serial debugging subtype (i.MX6, Generic Address Structure 16550-compatible) |
+| June 11, 2020 | Added new serial debugging subtype (SDM845v2) |
+| September 1, 2020 | Converted document to Markdown syntax and formatting changes. |
+
+## Introduction
+
+Microsoft requires a debug port on all systems. To describe the debug port(s) available on a platform, Microsoft defines an operating system–specific table (DBG2). This table specifies one or more independent ports for debugging purposes. The presence of a debug port table indicates that the system includes a debug port. The table contains information about the configuration of the debug port. The table is located in system memory with other Advanced Configuration and Power Interface (ACPI) tables, and must be referenced in the ACPI Root System Description Table (RSDT).
+
+The DBG2 table replaces the ACPI Debug Port Table (DBGP) on platforms whose debug port implementations cannot be described using DBGP.
+
+## Debug Port Table 2 (DBG2)
+
+Table 1 defines the fields in DBG2.
+
+**Table 1. Debug Port Table 2 format**
+
+| **Field** | **Byte length** | **Byte offset** | **Description** |
+|-----------|-----------------|-----------------|-----------------|
+| Header    |                 |                 |                 |
+| Signature | 4 | 0 | ‘DBG2’. Signature for Debug Port Table 2. |
+| Length | 4 | 4 | Length, in bytes, of the entire Debug Port Table 2. |
+| Revision | 1 | 8 | For this version of the specification, this value is 0. |
+| Checksum | 1 | 9 | Entire table must sum to zero. |
+| OEM ID | 6 | 10 | Original equipment manufacturer (OEM) ID. |
+| OEM Table ID | 8 | 16 | For Debug Port Table 2, the table ID is the manufacturer model ID. |
+| OEM Revision | 4 | 24 | OEM revision of Debug Port Table 2 for the supplied OEM Table ID. |
+| Creator ID | 4 | 28 | Vendor ID of utility that created the table. |
+| Creator Revision | 4 | 32 | Revision of utility that created the table. |
+| OffsetDbgDeviceInfo | 4 | 36 | Offset, in bytes, from the beginning of this table to the first Debug Device Information structure entry. |
+| NumberDbgDeviceInfo | 4 | 40 | Indicates the number of Debug Device Information structure entries. |
+| Debug Device Information Structure[NumberDbgDeviceInfo] | Variable | OffsetDbgDeviceInfo  | A list of Debug Device Information structures for this platform.  The structure format is defined in the Debug Device Information structure section, later in this document. |
+
+<br>
+
+## Debug Device Information structure
+
+**Table 2. Debug Device Information structure format**
+
+| **Field** | **Byte length** | **Byte offset** | **Description** |
+|-----------|-----------------|-----------------|-----------------|
+| Revision | 1 | 0 | Revision of the Debug Device Information structure. For this version of the specification, this must be 0. |
+| Length | 2 | 1 | Length, in bytes, of this structure, including NamespaceString and OEMData. |
+| NumberofGenericAddressRegisters | 1 | 3 | Number of generic address registers in use. |
+| NameSpaceStringLength | 2 | 4 | Length, in bytes, of NamespaceString, including null characters. |
+| NameSpaceStringOffset | 2 | 6 | Offset, in bytes, from the beginning of this structure to the field NamespaceString[]. This value must be valid because this string must be present. |
+| OemDataLength | 2 | 8 | Length, in bytes, of the OEM data block. |
+| OemDataOffset | 2 | 10 | Offset, in bytes, to the field OemData[] from the beginning of this structure. This value will be 0 if no OEM data is present. |
+| Port Type | 2 | 12 | Debug port type for this debug device. Each of these values will have a corresponding subtype value as shown in Table 3. |
+| Port Subtype | 2 | 14 | Debug port subtype for this debug device.  See Table 3. |
+| Reserved | 2 | 16 | Reserved, must be 0. |
+| BaseAddressRegisterOffset | 2 | 18 | Offset, in bytes, from beginning of this structure to the field BaseaddressRegister[]. |
+| AddressSizeOffset | 2 | 20 | Offset, in bytes, from beginning of this structure to the field AddressSize[]. |
+| BaseAddressRegister[] | (NumberofGenericAddressRegisters) * 12 | BaseAddressRegisterOffset | Array of generic addresses. |
+| AddressSize[] | (NumberofGenericAddressRegisters) * 4 | AddressSizeOffset | Array of address sizes corresponding to each generic address above. |
+| NamespaceString[] | NameSpaceStringLength | NameSpaceStringOffset | Null-terminated ASCII string to uniquely identify this device. This string consists of a fully qualified reference to the object that represents this device in the ACPI namespace. If no namespace device exists, NamespaceString[] must contain a period “.”. |
+| OemData[] | OemDataLength | OemDataOffset | Optional, variable-length OEM-specific data. |
+
+<br>
+
+**Table 3. Debug port types and subtypes**
+
+| **Port** | **Type** | **Subtype** | **Description** |
+|----------|----------|-------------|-----------------|
+| Reserved | 0x0000 – 0x7FFF and 0xFFFF | All | Reserved (Do Not Use) |
+| Serial   | 0x8000   | 0x0000      | Fully 16550-compatible |
+|          |          | 0x0001      | 16550 subset compatible with DBGP Revision 1 |
+|          |          | 0x0002      | Reserved (Do Not Use) |
+|          |          | 0x0003      | ARM PL011 UART |
+|          |          | 0x0004 – 0x000C | Reserved (Do Not Use) |
+|          |          | 0x000D      | (deprecated) ARM SBSA (2.x only) Generic UART supporting only 32-bit accesses |
+|          |          | 0x000E      | ARM SBSA Generic UART |
+|          |          | 0x000F      | ARM DCC |
+|          |          | 0x0010      | BCM2835 |
+|          |          | 0x0011      | SDM845 with clock rate of 1.8432 MHz |
+|          |          | 0x0012      | 16550-compatible with parameters defined in Generic Address Structure |
+|          |          | 0x0013      | SDM845 with clock rate of 7.372 MHz |
+|          |          | 0x0014 - 0xFFFF | Reserved (For Future Use) |
+| 1394     | 0x8001   | 0x0000      | IEEE1394 Standard Host Controller Interface |
+|          |          | 0x0001 – 0xFFFF | Reserved (For Future Use) |
+| USB      | 0x8002   | 0x0000      | XHCI-compliant controller with debug interface |
+|          |          | 0x0001      | EHCI-compliant controller with debug interface |
+|          |          | 0x0002 – 0x0006 | Reserved (Do Not Use) |
+|          |          | 0x0007 – 0xFFFF | Reserved (For Future Use) |
+| Net      | 0x8003   | NNNN        | NNNN must be a valid PCI-assigned Vendor ID |
+|          | 0x8004   | All         | Reserved (Do Not Use) |
+| Reserved | 0x8005 – 0xFFFE | All  | Reserved (For Future Use) |
+
+<br>
+
+### Note on the fields of the Generic Address Structure
+
+* The Generic Address Structure in BaseAddressRegister[0] is used to specify the register bit width and access size used by some serial subtypes.
+* The Address Space ID and Register Bit Offset fields must be 0.
+* The Register Bit Width field contains the register stride and must be a power of 2 that is at least as large as the access size. On 32-bit platforms this value cannot exceed 32. On 64-bit platforms this value cannot exceed 64.
+* The Access Size field is used to determine whether byte, WORD, DWORD, or QWORD accesses are to be used. QWORD accesses are only valid on 64-bit architectures.
+
+## Resources
+
+* ACPI Specification
+  * http://uefi.org/specifications

--- a/windows-driver-docs-pr/bringup/acpi-system-description-tables.md
+++ b/windows-driver-docs-pr/bringup/acpi-system-description-tables.md
@@ -85,7 +85,7 @@ Microsoft requires a debug port on all systems. To describe the debug port(s) bu
 
 Windows uses the Port Type value in the DBG2 table to identify and load the Kernel Debugger (KD) transport (for example, USB or serial) that the system requires. The KD transport then uses the Port Subtype value in the DBG2 table to identify the hardware interface used by the port. Other information in the DBG2 table specifies the system address of the port registers, which is used by the hardware interface module for the specified subtype. Finally, the DBG2 table must include a reference to the device node in the ACPI namespace that corresponds to the debug port. This reference enables Windows to manage conflicts between debugging use and normal use of the device, if any, and also to integrate the debugger with power transitions.
 
-For more information, see the [Microsoft Debug Port Table 2 (DBG2) specification](/previous-versions/windows/hardware/design/dn639131(v=vs.85)).
+For more information, see the [Microsoft Debug Port Table 2 (DBG2) specification](acpi-debug-port-table.md).
 
 ## Differentiated System Description Table (DSDT)
 

--- a/windows-driver-docs-pr/serports/serial-port-console-redirection-table.md
+++ b/windows-driver-docs-pr/serports/serial-port-console-redirection-table.md
@@ -49,7 +49,7 @@ This table must be located in system memory with other ACPI tables, and it must 
 | PCI Device ID | 2 | 64 | Must be 0xFFFF if it is not a PCI device. |
 | PCI Vendor ID | 2 | 66 | Must be 0xFFFF if it is not a PCI device. |
 | PCI Bus Number | 1 | 68 | PCI Bus Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI device.</p> |
-| PCI Device Number | 1 | 69 | PCI Slot Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI devic.</p>|
+| PCI Device Number | 1 | 69 | PCI Slot Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI device.</p>|
 | PCI Function Number | 1 | 70 | PCI Function Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI device.</p> |
 | PCI Flags | 4 | 71 | PCI Compatibility flags bitmask.  Should be zero by default.<ul><li>Bit[0]: Operating System should NOT suppress PNP device enumeration or disable power management for this device. Must be 0 if it is not a PCI device</li><li>Bit[1-31]: Reserved, must be zero.</li></ul>|
 | PCI Segment | 1 | 75 | PCI segment number. <p>For systems with fewer than 255 PCI buses, this number must be 0. </p>|

--- a/windows-driver-docs-pr/serports/serial-port-console-redirection-table.md
+++ b/windows-driver-docs-pr/serports/serial-port-console-redirection-table.md
@@ -1,10 +1,11 @@
 ---
 title: Serial Port Console Redirection Table (SPCR)
-description: The Serial Port Console Redirection Table that is used to indicate whether a serial port or a non-legacy UART interface is available for use with Microsoft® Windows® Emergency Management Services (EMS). 
+description: The Serial Port Console Redirection Table that is used to indicate whether a serial port or a non-legacy UART interface is available for use with Microsoft® Windows® Emergency Management Services (EMS).
 ms.assetid: cbcd2e71-881a-44f6-b3d8-5d2aadb02b27
 keywords:
 - SPCR
-- EMS UART
+- EMS
+- UART
 ms.date: 07/23/2018
 ---
 
@@ -34,9 +35,9 @@ This table must be located in system memory with other ACPI tables, and it must 
 | OEM Revision | 4 | 24 | OEM revision of Serial Port Console Redirection Table for supplied OEM Table ID. |
 | Creator ID | 4 | 28 | Vendor ID of utility that created the table. For the DSDT, RSDT, SSDT, and PSDT tables, this is the ID for the ASL Compiler. |
 | Creator Revision | 4 | 32 | Revision of utility that created the table. For the DSDT, RSDT, SSDT, and PSDT tables, this is the revision for the ASL Compiler. |
-| Interface Type | 1 | 36 | Indicates the type of the register interface: <p> For Revision 1: </p> <ul><li>0 = full 16550 interface </li><li>1 = full 16450 interface (must also accept writing to the 16550 FCR register) </li><li>2-255 = reserved </li></ul><p>For Revision 2: <p>See the Serial Port Subtypes in Table 3 of the [DBG2 Specification](/previous-versions/windows/hardware/design/dn639131(v=vs.85)) </p>|
+| Interface Type | 1 | 36 | Indicates the type of the register interface: <p> For Revision 1: </p> <ul><li>0 = full 16550 interface </li><li>1 = full 16450 interface (must also accept writing to the 16550 FCR register) </li><li>2-255 = reserved </li></ul><p>For Revision 2: <p>See the Serial Port Subtypes in Table 3 of the [DBG2 Specification](../bringup/acpi-debug-port-table.md) </p>|
 | Reserved | 3 | 37 | Must be 0. |
-| Base Address | 12 | 40|<p>The base address of the Serial Port register set described using the ACPI Generic Address Structure.</p>0 = console redirection disabled <p>**Note:** <p>COM1 (0x3F8) would be:</p><ul><li>Integer Form: 0x 01 08 00 00 00000000000003F8</li><li>Viewed in Memory: 0x01080000F803000000000000</li></ul><p>COM2 (Ox2F8) would be:<ul><li>Integer Form: 0x 01 08 00 00 00000000000002F8</li><li>Viewed in Memory: 0x01080000F802000000000000 </li></ul>|
+| Base Address | 12 | 40|<p>The base address of the Serial Port register set described using the ACPI Generic Address Structure.</p>0 = console redirection disabled <p>**Note:** <p>COM1 (0x3F8) would be:</p><ul><li>Integer Form: 0x 01 08 00 00 00000000000003F8</li><li>Viewed in Memory: 0x01080000F803000000000000</li></ul><p>COM2 (0x2F8) would be:<ul><li>Integer Form: 0x 01 08 00 00 00000000000002F8</li><li>Viewed in Memory: 0x01080000F802000000000000 </li></ul>|
 | Interrupt Type | 1 | 52 | Interrupt type(s) used by the UART:<ul><li>Bit[0]: PC-AT-compatible dual-8259 IRQ interrupt</li><li>Bit[1]: I/O APIC interrupt (Global System Interrupt)</li><li>Bit[2]: I/O SAPIC interrupt (Global System Interrupt)</li><li>Bit[3]: ARMH GIC interrupt (Global System Interrupt)</li><li>Bit[4:7]: Reserved (Must be set to 0)</li></ul> Where <ul><li>0 = Not supported</li><li>1 = Supported</li></ul> Platforms with both a dual-8259 and an I/O APIC or I/O SAPIC must set the IRQ bit (Bit[0]) and the corresponding Global System Interrupt bit. (e.g. a system that supported 8259 and SAPIC would be 5)|
 | IRQ | 1 | 53 | The PC-AT-compatible IRQ used by the UART: <ul><li>2-7, 9-12, 14-15 = Valid IRQs respectively</li><li>0-1, 8, 13, 16-255 = Reserved</li></ul> Valid only if Bit[0] of the Interrupt Type field is set. |
 | Global System Interrupt | 4 | 54 | The Global System Interrupt (GSIV) used by the UART. <p>Not valid if Bit[0] is the only bit set in the Interrupt Type field. </p>|
@@ -44,15 +45,15 @@ This table must be located in system memory with other ACPI tables, and it must 
 | Parity| 1 | 59 | <ul><li>0 = No Parity</li><li>1-255 = Reserved</li></ul> |
 | Stop Bits| 1 | 60 | <ul><li>0 = Stop bit</li><li>1-255 = Reserved</li></ul> |
 | Terminal Type | 1 | 62 |The terminal protocol the BIOS was using for console redirection:<ul><li>0 = VT100</li><li>1 = VT100+</li><li>2 = VT-UTF8</li><li>3 = ANSI<li>4-255 = Reserved </li></ul>|
-| Reserved | 1 | 63 | Must be 0 |
-| PCI Device ID | 2 | 64 | Must be 0xFFFF if it is not a PCI device |
-| PCI Vendor ID | 2 | 66 | Must be 0xFFFF if it is not a PCI device |
-| PCI Bus Number | 1 | 68 | PCI Bus Number if table describes a PCI device<p>Must be 0x00 if it is not a PCI device</p> |
-| PCI Device Number | 1 | 69 | PCI Slot Number if table describes a PCI device<p>Must be 0x00 if it is not a PCI device</p>|
-| PCI Function Number | 1 | 70 | PCI Function Number if table describes a PCI device<p>Must be 0x00 if it is not a PCI device</p> |
+| Reserved | 1 | 63 | Must be 0. |
+| PCI Device ID | 2 | 64 | Must be 0xFFFF if it is not a PCI device. |
+| PCI Vendor ID | 2 | 66 | Must be 0xFFFF if it is not a PCI device. |
+| PCI Bus Number | 1 | 68 | PCI Bus Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI device.</p> |
+| PCI Device Number | 1 | 69 | PCI Slot Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI devic.</p>|
+| PCI Function Number | 1 | 70 | PCI Function Number if table describes a PCI device.<p>Must be 0x00 if it is not a PCI device.</p> |
 | PCI Flags | 4 | 71 | PCI Compatibility flags bitmask.  Should be zero by default.<ul><li>Bit[0]: Operating System should NOT suppress PNP device enumeration or disable power management for this device. Must be 0 if it is not a PCI device</li><li>Bit[1-31]: Reserved, must be zero.</li></ul>|
 | PCI Segment | 1 | 75 | PCI segment number. <p>For systems with fewer than 255 PCI buses, this number must be 0. </p>|
-| Reserved | 4 | 76 | Must be 0 |
+| Reserved | 4 | 76 | Must be 0. |
 
 ## Revision History
 
@@ -81,5 +82,6 @@ This table must be located in system memory with other ACPI tables, and it must 
 | 3/12/14   | 1.01 | Released under Microsoft Community Promise|
 | 6/2/14    | 1.02 | Changed Table Revision to 2 and added support for additional Interface Types, as defined in the DBG2 specification.|
 | 8/10/15   | 1.03 | Updated patent notice.|
-| 7/23/2018 | 1.04| |
+| 7/23/2018 | 1.04 | |
 | 6/5/2020  | 1.05 | Edited formatting|
+| 9/1/2020  | 1.06 | Edited formatting and updated link to DBG2 specification|


### PR DESCRIPTION
This change submits the latest DBG2 ACPI table specification as a Markdown document (to replace the deprecated Word document version).