### PR TITLE
Critical typo fixes

### DIFF
--- a/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
+++ b/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
@@ -58,5 +58,5 @@ The first column indicates the selection state in the **Driver Delivery Options*
 |Regular Automatic Update only|No|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
 |Dynamic Update only|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Only in Windows 10, version 1909 and earlier|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|No|
 |Manual in Windows 10, version 1909 and earlier|No|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|N/A|
-|Manual starting in Windows 10, version 2004 and later|No|No|No|No|Yes|
+|Manual starting in Windows 10, version 2004|No|No|No|No|Yes|
 

--- a/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
+++ b/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
@@ -52,11 +52,11 @@ Here's a table that summarizes the information above.
 
 The first column indicates the selection state in the **Driver Delivery Options** section. The first checkbox (**Automatically delivered during Windows Updates**) is indicated by Dynamic Update, and the second (**Automatically delivered to all applicable systems**) is indicated by Regular **Automatic** Update. **Manual** indicates **Optional/Manual** drivers, and Windows Update is abbreviated WU.
 
-|Driver Delivery Options|OS Upgrades|Connect New Device|Device Manager|Windows Update daily scan or **Check for Updates** button|Windows Update Optional page|
+|Driver delivery options|OS upgrades|Connecting new device|Device Manager|WU scan|"Optional updates" page|
 |-|-|-|-|-|-|
 |Automatic (default)|Yes|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
 |Regular Automatic Update only|No|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
 |Dynamic Update only|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Only in Windows 10, version 1909 and earlier|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|No|
-|Manual in Windows 10, version 1909 and earlier|No|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|No|
-|Manual starting in Windows 10, version 2004|No|No|No|No|No|
+|Manual in Windows 10, version 1909 and earlier|No|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|N/A|
+|Manual starting in Windows 10, version 2004 and later|No|No|No|No|Yes|
 


### PR DESCRIPTION
Starting with Windows 10 v20H1, a new "Optional updates" page has been added to the Settings app, Windows Update section. However, the corresponding column in this article contained only "No", which seemed strange to me. I [found a Microsoft source that said this column must contain "N/A" and "Yes" respectively for the last two rows](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/redefining-manual-driver-updates/). (To be honest, I found that Microsoft source first.)

Also, I normalized the capitalization of the heading row of the table and eliminated verbosity. Windows 10 v20H2 is rolling out, so I reflected this fact in the last row.