### PR TITLE
Update understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md

### DIFF
--- a/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
+++ b/windows-driver-docs-pr/dashboard/understanding-windows-update-automatic-and-optional-rules-for-driver-distribution.md
@@ -6,13 +6,13 @@ ms.topic: article
 ms.localizationpriority: medium
 ---
 
-# Understanding Windows Update Automatic and Optional Rules for Driver Distribution
+# Understanding Windows Update rules for driver distribution
 
 This article describes how you can control when Windows Update distributes your driver.
 
 When [submitting a driver to Windows Update](publish-a-driver-to-windows-update.md), the **Driver Delivery Options** section presents two radio buttons: **Automatic** and **Manual**
 
-Under the **Automatic** option there are two checkboxes: **Automatically delivered during Windows Updates** and **Automatically delivered to all applicable systems**. **Automatic** is the default setting for all new shipping labels.
+Under the **Automatic** option there are two checkboxes: **Automatically delivered during Windows Upgrades** and **Automatically delivered to all applicable systems**. **Automatic** is the default setting for all new shipping labels.
 
 ![Automatic driver promotions checkboxes](images/driver-delivery-options.png)
 
@@ -22,41 +22,44 @@ When the second checkbox is selected, the driver is downloaded and installed aut
 
 For more info about the **Manual** option, see [Publish a driver to Windows Update](publish-a-driver-to-windows-update.md).
 
-## Automatic updates
-
-During a scheduled update or when a user selects **Check for updates** in the **Updates & Security** settings menu, Windows Update distributes only the highest-ranking **Automatic drivers** that apply to the system's devices.
-
-## Optional/Manual updates
-
-In Windows 10, version 1909 and earlier, Windows Update automatically distributes **Optional/Manual** drivers in the following scenarios:
-* A device has no applicable drivers available in the Driver Store ("Driver Not Found"), and there is no applicable **Automatic** driver
-* Or *if the only locally available driver is generic*, meaning a system-provided driver that provides only basic device functionality, and there is no applicable **Automatic** driver
-
-## Device plug-in ("Plug and Play")
+## Connecting new devices
 
 When a device is connected to a Windows system, [Plug and Play (PnP)](../kernel/introduction-to-plug-and-play.md) looks for a compatible driver already available on the computer. If one exists, Windows installs it on the device. Otherwise, Windows searches Windows Update for a compatible driver, first matching the highest-ranking **Automatic** driver on Windows Update.
 
-In Windows 10, version 1909 and earlier, if no **Automatic** driver is available for the device, Windows proceeds to the highest-ranking **Optional/Manual** driver.
+In Windows 10, version 1909 and earlier, if no **Automatic** driver is available for the device, Windows proceeds to the highest-ranking **Manual** driver.
 
-Starting in Windows 10, version 2004, Windows does not search for an **Optional/Manual** driver when an **Automatic** driver is not available. To acccess **Optional/Manual** drivers, go to: **Settings > Update & Security > Windows Update > View optional updates > Driver updates**.
+Starting with Windows 10, version 2004, Windows does not search for a **Manual** driver when an **Automatic** driver is not available.
 
-## Device manager
+## Device Manager
 
-In Windows 10, version 1909 and earlier, when a user searches for updated drivers in Device Manager, Windows attempts to install the highest-ranking driver from Windows Update, regardless of whether it is classified as **Automatic** or **Optional/Manual**.
+In Windows 10, version 1909 and earlier, when a user searches for updated drivers in Device Manager, Windows attempts to install the highest-ranking driver from Windows Update, regardless of whether it is classified as **Automatic** or **Manual**.
 
-Starting in Windows 10 version 2004, when a user searches for updated drivers in Device Manager, Windows searches only drivers on the computer. To search online, use the *Windows Update Settings page*.
+Starting with Windows 10 version 2004, when a user searches for updated drivers in Device Manager, Windows only searches the local computer.
+
+## Windows Update scan
+
+During a Windows Update scan (be it scheduled or user-initiated,) Windows Update distributes only the highest-ranking **Automatic** drivers that apply to the system's devices.
+
+In all versions of Windows 10, upon failing to find a driver, Device Manager recommends the user to try Windows Update. In version 1909 and earlier, this recommendation merely helped making sure that the Windows Update agent is in working condition. Starting with version 2004, it has become a functional recommmendation for reaching the **Automatic**, and eventually, the **Manual** drivers.
+
+## "Optional updates" page
+
+In Windows 10, version 1909 and earlier, Windows Update automatically distributes **Manual** drivers in either of the following scenarios:
+
+* A device has no applicable drivers available in the Driver Store (raising a "driver not found" error), and there is no applicable **Automatic** driver
+* A device has only a generic driver in the Driver Store, which provides only basic device functionality, and there is no applicable **Automatic** driver
+
+Starting with Windows 10, version 2004, the Windows Update agent page in the Settings app has an "Optional updates" sub-page. This page distributes **Manual** drivers.
 
 ## Summary
 
-Here's a table that summarizes the information above.
-
-The first column indicates the selection state in the **Driver Delivery Options** section. The first checkbox (**Automatically delivered during Windows Updates**) is indicated by Dynamic Update, and the second (**Automatically delivered to all applicable systems**) is indicated by Regular **Automatic** Update. **Manual** indicates **Optional/Manual** drivers, and Windows Update is abbreviated WU.
+Here's a table that summarizes the information above. "WU" stands for "Windows Update"
 
 |Driver delivery options|OS upgrades|Connecting new device|Device Manager|WU scan|"Optional updates" page|
 |-|-|-|-|-|-|
-|Automatic (default)|Yes|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
-|Regular Automatic Update only|No|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
-|Dynamic Update only|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Only in Windows 10, version 1909 and earlier|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|No|
+|Automatic (both checkboxes)|Yes|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
+|Automatic (to all applicable systems)|No|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Yes|No|
+|Automatic (during Windows Upgrades)|Yes|Only if the local driver is generic or missing|Only in Windows 10, version 1909 and earlier|Only if the local driver is generic or missing|No|
 |Manual in Windows 10, version 1909 and earlier|No|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|Yes|Only if the local driver is generic or missing, and WU has no applicable **Automatic** driver|N/A|
-|Manual starting in Windows 10, version 2004|No|No|No|No|Yes|
+|Manual in Windows 10, version 2004 and later|No|No|No|No|Yes|
 


### PR DESCRIPTION
- Delete two instances of the phrase "and WU has no applicable **Automatic** driver" from table row #4 (counting the heading). How can an Automatic driver be installed when Windows Update has no Automatic drivers?
- Correct all misquotations of the screenshot. Since the content of the screenshot does not appear in a GitHub diff, here is what it says:
    - "Automatic"
        - "Automatically delivered during Windows Upgrades"
        - "Automatically delivered to all applicable systems"
    - "Manual"
- In concert with the above, replace the following confusing phrases with the exact wordings of the screenshot
    - "indicated by Dynamic Update"
    - "Optional/Manual"
    - "during Windows Updates"
- Reorganize sections for better comprehension. Upon connecting a new device, the user goes (or should go anyway) through the following stages in order: Waiting for PnP, using Device Manager, using Windows Update, and finally, using the optional updates.
- Update the title to use natural capitalization and be less verbose. All of this page's siblings on Microsoft Docs use the natural case already.