### PR TITLE
Correcting typo in code window

### DIFF
--- a/windows-driver-docs-pr/install/the-testsigning-boot-configuration-option.md
+++ b/windows-driver-docs-pr/install/the-testsigning-boot-configuration-option.md
@@ -31,13 +31,13 @@ Run BCDEdit command lines to enable or disable the loading of test-signed code. 
 
 To enable test-signed code, use the following BCDEdit command line:
 
-```cpp
+```cmd
 Bcdedit.exe -set TESTSIGNING ON
 ```
 
 To disable use of test-signed code, use the following BCDEdit command line:
 
-```cpp
+```cmd
 Bcdedit.exe -set TESTSIGNING OFF
 ```
 


### PR DESCRIPTION
The commands being shown in the code window are in fact not C++ lines of code, but is a command to be entered into the CMD command prompt. 
Adjusting text to correctly reflect that.