### PR TITLE
@PnpLockDown grammar: prevent(s)

### DIFF
--- a/windows-driver-docs-pr/network/version-section-in-a-network-inf-file.md
+++ b/windows-driver-docs-pr/network/version-section-in-a-network-inf-file.md
@@ -106,7 +106,7 @@ The **Signature** entry must be **$Windows NT$**.
 
 ### PnpLockDown
 
-The **PnpLockDown** entry should be set to 1 to prevents applications from directly modifying the files that your driver package's INF file specifies. For more information about this entry, see [**INF Version Section**](../install/inf-version-section.md).
+The **PnpLockDown** entry should be set to 1 to prevent applications from directly modifying the files that your driver package's INF file specifies. For more information about this entry, see [**INF Version Section**](../install/inf-version-section.md).
 
 ### CatalogFile
 


### PR DESCRIPTION
prevents applications -> prevent applications (I guess?)
" entry should be set to 1 to **prevents** applications from directly "
 ->
"  entry should be set to 1 to **prevent** applications from directly  "

**1 thing now when I look closer, sorry it was maybe wrong;  I am unsure now. (It's hard to see what's correct for me anyway)** 

Please if this is incorrect, tell me that; sorry if it was