### PR TITLE
should not link to 2.3.2 version of CLI

### DIFF
--- a/windows-driver-docs-pr/devtest/static-tools-and-codeql.md
+++ b/windows-driver-docs-pr/devtest/static-tools-and-codeql.md
@@ -49,7 +49,7 @@ We will use the [CodeQL command line tools (CLI)](https://help.semmle.com/codeql
 C:\> mkdir C:\codeql-home
 ```
 
-2. Navigate to the Github [CodeQL Download Page](https://github.com/github/codeql-cli-binaries/releases/tag/v2.3.2)
+2. Navigate to the Github [CodeQL Download Page](https://github.com/github/codeql-cli-binaries/releases/)
 3. Download the appropriate zip file. For example for 64 bit Windows "codeql-win64.zip".
 4. Unzip the downloaded zip file to a directory, for example,  C:\codeql-home\codeql-win64
 5. Confirm that the CodeCL command works by displaying the help.


### PR DESCRIPTION
needs to link to the main releases page so that the user picks up the latest release.  this caused issues with another customer