### PR TITLE
Make the audio signal processing modes easier to read

### DIFF
--- a/windows-driver-docs-pr/audio/ksproperty-audiosignalprocessing-modes.md
+++ b/windows-driver-docs-pr/audio/ksproperty-audiosignalprocessing-modes.md
@@ -57,15 +57,17 @@ The property value is a structure, followed by zero (0) or more GUIDs.
 
 **KSPROPERTY\_AUDIOSIGNALPROCESSING\_MODES** returns a **KSMULTIPLE\_ITEM** followed by zero (0) or more GUIDS. The KSMULTIPLE\_ITEM.Count member contains the number of GUIDs. The KSMULTIPLE\_ITEM.Size member contains the total size of the property value. Each GUID identifies a signal processing mode supported by the audio driver for the Pin ID specified in the *PinId* member of the **KSP\_PIN** structure.
 
-In Windows 8.1 there were two defined audio signal processing modes, AUDIO\_SIGNALPROCESSINGMODE\_DEFAULT and AUDIO\_SIGNALPROCESSINGMODE\_RAW.
+In Windows 8.1 there were two defined audio signal processing modes:
+* AUDIO\_SIGNALPROCESSINGMODE\_DEFAULT
+* AUDIO\_SIGNALPROCESSINGMODE\_RAW.
 
-In Windows 10, five additional mode are defined.
+In Windows 10, five additional mode are defined:
+* AUDIO\_SIGNALPROCESSINGMODE\_COMMUNICATIONS
+* AUDIO\_SIGNALPROCESSINGMODE\_SPEECH
+* AUDIO\_SIGNALPROCESSINGMODE\_MEDIA
+* AUDIO\_SIGNALPROCESSINGMODE\_MOVIE
+* AUDIO\_SIGNALPROCESSINGMODE\_NOTIFICATION
 
-AUDIO\_SIGNALPROCESSINGMODE\_COMMUNICATIONS
-AUDIO\_SIGNALPROCESSINGMODE\_SPEECH
-AUDIO\_SIGNALPROCESSINGMODE\_MEDIA
-AUDIO\_SIGNALPROCESSINGMODE\_MOVIE
-AUDIO\_SIGNALPROCESSINGMODE\_NOTIFICATION
 For more information, see [Audio Signal Processing Modes](./audio-signal-processing-modes.md).
 
 Remarks


### PR DESCRIPTION
Change the audio processing modes into a list for easier reading and move the phrase pointing to additional documentation to a new paragraph.