### PR TITLE
Change descriptions of some registry keys

### DIFF
--- a/windows-driver-docs-pr/audio/portcls-registry-power-settings.md
+++ b/windows-driver-docs-pr/audio/portcls-registry-power-settings.md
@@ -38,7 +38,7 @@ By default, Windows 8 has power settings that PortCls uses to determine whether
 <td align="left">ConservationIdleTime</td>
 <td align="left">REG_BINARY</td>
 <td align="left">0</td>
-<td align="left">0-second timeout.</td>
+<td align="left">Idle timeout for the device, when the system is on battery power.</td>
 </tr>
 <tr class="even">
 <td align="left">IdlePowerState</td>
@@ -54,7 +54,7 @@ By default, Windows 8 has power settings that PortCls uses to determine whether
 <td align="left">PerformanceIdleTime</td>
 <td align="left">REG_BINARY</td>
 <td align="left">0</td>
-<td align="left">0-second timeout.</td>
+<td align="left">Idle timeout for the device, when the system is on AC power.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Change the description for _ConservationIdleTime_ and _PerformanceIdleTime_ to better reflect when they are used.