### PR TITLE
Update laptop-slate-mode-toggling-between-states.md

### DIFF
--- a/windows-driver-docs-pr/gpiobtn/laptop-slate-mode-toggling-between-states.md
+++ b/windows-driver-docs-pr/gpiobtn/laptop-slate-mode-toggling-between-states.md
@@ -40,7 +40,7 @@ int __cdecl ToggleConversionIndicator(
 }
 ```
 
- 
+<b>Note:</b> The laptop/slate mode indicator device can be opened by only one process at a time. CreateFile will fail and GetLastError will return ERROR_ACCESS_DENIED when the device is already opened by another process. 
 
  
 


### PR DESCRIPTION
Add comment indicating that CreateFile can fail with ERROR_ACCESS_DENIED when the GPIO Slate/Laptop Indicator device is already opened by another process (or the system).