### PR TITLE
Updated intermediate certificate to leaf certificate in what will hap…

### DIFF
--- a/windows-driver-docs-pr/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates.md
+++ b/windows-driver-docs-pr/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates.md
@@ -76,7 +76,7 @@ For more info, see [Signing drivers during development and test](./introduction-
 
 ### What will happen to my existing signed driver packages? 
 
-As long as driver packages are timestamped before the expiration date of the intermediate certificate, they will continue working.
+As long as driver packages are timestamped before the expiration date of the leaf signing certificate, they will continue working.
 
 ### Is there a way to run production driver packages without exposing it to Microsoft? 
 


### PR DESCRIPTION
…pen to my existing signed driver package

The timestamp must be between the ValidFrom and ValidTo dates on the leaf certificate, not the intermediate certificate. Correcting this point as a partner asked about this recently. 