### PR TITLE
Fix Built-in_drivers_for_USB_devices link

### DIFF
--- a/windows-driver-docs-pr/gettingstarted/do-you-need-to-write-a-driver-.md
+++ b/windows-driver-docs-pr/gettingstarted/do-you-need-to-write-a-driver-.md
@@ -13,7 +13,7 @@ Microsoft Windows contains built-in drivers for many device types. If there is a
 ## <span id="Built-in_drivers_for_USB_devices"></span><span id="built-in_drivers_for_usb_devices"></span><span id="BUILT-IN_DRIVERS_FOR_USB_DEVICES"></span>Built-in drivers for USB devices
 
 
-If your device belongs to a device class that is defined by the USB Device Working Group (DWG), there may already be an existing Windows USB class driver for it. For more information, see [Drivers for the Supported USB Device Classes](/windows-hardware/drivers/ddi/index).
+If your device belongs to a device class that is defined by the USB Device Working Group (DWG), there may already be an existing Windows USB class driver for it. For more information, see [Drivers for the Supported USB Device Classes](/windows-hardware/drivers/usbcon/supported-usb-classes).
 
 ## <span id="Built-in_drivers_for_other_devices"></span><span id="built-in_drivers_for_other_devices"></span><span id="BUILT-IN_DRIVERS_FOR_OTHER_DEVICES"></span>Built-in drivers for other devices
 


### PR DESCRIPTION
Currently `Drivers for the Supported USB Device Classes` point to https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/
but I believe it means https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/supported-usb-classes#microsoft-provided-usb-device-class-drivers