### PR TITLE
Add release branch table for Static Tools Logo test

### DIFF
--- a/windows-driver-docs-pr/devtest/static-tools-and-codeql.md
+++ b/windows-driver-docs-pr/devtest/static-tools-and-codeql.md
@@ -82,11 +82,18 @@ Commands:
 
 1. Navigate to the [Microsoft CodeQL GitHub repository](https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools).
 
-2. [Clone](https://github.com/git-guides/git-clone) the repository to download all CodeQL queries and [query suites](https://codeql.github.com/docs/codeql-cli/creating-codeql-query-suites/) with driver-specific queries.
+2. [Clone](https://github.com/git-guides/git-clone) the repository to download all CodeQL queries and [query suites](https://codeql.github.com/docs/codeql-cli/creating-codeql-query-suites/) with driver-specific queries.  
 
 ```command
-C:\codeql-home\>git clone https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools.git --recursive
+C:\codeql-home\>git clone https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools.git --recursive -b RELEASE_BRANCH
 ```
+
+Replace RELEASE_BRANCH with the appropriate branch depending on the OS you are certifying for, per the following table:
+
+| Release                         | Branch to use   |
+|---------------------------------|-----------------|
+| Windows Server 2022             | WHCP_21H2       |
+| Windows October 2021 Release    | WHCP_21H2       |
 
 > [!NOTE]
 > Usage of CodeQL for the purpose of WHCP testing is acceptable under the **[Hardware Lab Kit (HLK)](/windows-hardware/test/hlk/) End User License Agreement**.  For WHCP participants, the HLK's EULA overwrites GitHub's CodeQL Terms and Conditions.  The HLK EULA states that CodeQL **can be used** during automated analysis, CI or CD, as part of normal engineering processes for the purposes of analyzing drivers to be submitted and certified as part of the WHCP.


### PR DESCRIPTION
This adds a table indicating which branch of our CodeQL queries should be used for certifying drivers with CodeQL for a given release.  At present this is only Windows Server 2022 and the October 2021 release.