### PR TITLE
Delete **PropPageExt.dll** line from  copy files

### DIFF
--- a/windows-driver-docs-pr/audio/audio-universal-drivers.md
+++ b/windows-driver-docs-pr/audio/audio-universal-drivers.md
@@ -195,7 +195,6 @@ Complete the following steps to build the sysvad sample for Windows 10 desktop.
 | tabletaudiosample.inf      | An information (INF) file that contains information needed to install the driver. |
 | sysvad.cat                 | The catalog file.                                                                 |
 | SwapAPO.dll                | A sample driver extension for a UI to manage APOs.                                |
-| PropPageExt.dll            | A sample driver extension for a property page.                                    |
 | KeywordDetectorAdapter.dll | A sample keyword detector.                                                        |
 
 ## Install and test the driver


### PR DESCRIPTION
Unfortunately, Universal Windows Drivers does not allow this property page and has been removed from the sample code. Therefore, **PropPageExt.dll** cannot be copied.