### PR TITLE
Update WHQL docs to refer to HLK instead of HCK

### DIFF
--- a/windows-driver-docs-pr/install/whql-release-signature.md
+++ b/windows-driver-docs-pr/install/whql-release-signature.md
@@ -16,15 +16,15 @@ ms.localizationpriority: medium
 # WHQL Release Signature
 
 
-[Driver packages](driver-packages.md) that pass [Windows Hardware Certification Kit (HCK)](/windows-hardware/test/hlk/) testing can be digitally-signed by WHQL. If your driver package is digitally-signed by WHQL, it can be distributed through the [Windows Update](/windows-hardware/drivers) program or other Microsoft-supported distribution mechanisms.
+[Driver packages](driver-packages.md) that pass [Windows Hardware Lab Kit (HLK)](/windows-hardware/test/hlk/) testing can be digitally-signed by WHQL. If your driver package is digitally-signed by WHQL, it can be distributed through the [Windows Update](/windows-hardware/drivers) program or other Microsoft-supported distribution mechanisms.
 
-Obtaining a WHQL release signature is part of the [Windows Hardware Certification Kit (HCK)](/windows-hardware/test/hlk/). A WHQL release signature consists of a digitally-signed [catalog file](catalog-files.md). The digital signature does not change the driver binary files or the INF file that you submit for testing.
+Obtaining a WHQL release signature is part of the [Windows Hardware Lab Kit (HLK)](/windows-hardware/test/hlk/). A WHQL release signature consists of a digitally-signed [catalog file](catalog-files.md). The digital signature does not change the driver binary files or the INF file that you submit for testing.
 
 Obtaining a WHQL release signature consists of the following:
 
--   Testing the [driver package](driver-packages.md) with the Windows HCK to verify that the driver package is compatible with Microsoft Windows. Once the HCK is installed, the Driver Test Manager (DTM) is run to test and verify the driver package. For more information, see the [Windows Hardware Certification Kit (HCK)](/windows-hardware/test/hlk/).
+-   Testing the [driver package](driver-packages.md) with the Windows HCK to verify that the driver package is compatible with Microsoft Windows. Once the HCK is installed, the Driver Test Manager (DTM) is run to test and verify the driver package. For more information, see the [Windows Hardware Lab Kit (HLK)](/windows-hardware/test/hlk/).
 
--   Submitting DTM test logs to the Windows Quality Online Services to obtain a WHQL release signature for the driver package. For more information, see the [Windows Hardware Certification Kit (HCK)](/windows-hardware/test/hlk/).
+-   Submitting DTM test logs to the Windows Quality Online Services to obtain a WHQL release signature for the driver package. For more information, see the [Windows Hardware Lab Kit (HLK)](/windows-hardware/test/hlk/).
 
 For more information about WHQL, see the [Windows Hardware Quality Labs](/previous-versions/windows/hardware/hck/jj124227(v=vs.85)) website.
 


### PR DESCRIPTION
The name was changed at some point from Hardware Certification Kit to Hardware Lab Kit. This updates the text to match the page it links to