### PR TITLE
Fixing bad link

### DIFF
--- a/windows-driver-docs-pr/devtest/using-static-driver-verifier-to-find-defects-in-drivers.md
+++ b/windows-driver-docs-pr/devtest/using-static-driver-verifier-to-find-defects-in-drivers.md
@@ -104,7 +104,7 @@ Use the following steps to prepare your code for analysis.
 
     Static Driver Verifier detects the type of driver you are analyzing (WDF, WDM, NDIS, or Storport) and selects the default set of rules for your driver type. If this is the first time you are running SDV on your driver, you should run the default rule set.
 
-    For information about the rules, see [DDI Compliance Rules](/windows-hardware/drivers/ddi/index).
+    For information about the rules, see [DDI Compliance Rules](/windows-hardware/drivers/devtest/static-driver-verifier-rules).
 
 5. Start the static analysis. Click the **Main** tab, and click **Start**. When you click **Start**, a message is displayed to let you know that static analysis is scheduled and that the analysis can take a long time to run. Click **OK** to continue. The analysis begins at the time you scheduled.
 


### PR DESCRIPTION
DDI Compliance Rules link is dead. Fixed link to go to https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/static-driver-verifier-rules