### PR TITLE
Update DV documentation to point to new volatile commands; Remove outdated Autofail deprecation notice

### DIFF
--- a/windows-driver-docs-pr/devtest/driver-verifier--what-s-new.md
+++ b/windows-driver-docs-pr/devtest/driver-verifier--what-s-new.md
@@ -16,6 +16,9 @@ ms.localizationpriority: medium
 * [Driver Verifier in Windows Vista](#driver-verifier-in-windows-vista-updated-february-9-2009)
 * [Driver Verifier in Windows XP](#driver-verifier-in-windows-xp-updated-december-4-2001)
 
+## Driver Verifier in Windows 11 (*Updated: September 30, 2021*)
+Starting with Windows 11, many flags are now enabled without reboot using a different command syntax than the [volatile syntax](./using-volatile-settings.md). See [Driver Verifier Command Syntax](./verifier-command-line.md) for more information about the new syntax.
+
 ## Driver Verifier in Windows 10 (*Updated: May 8, 2018*)
 
 > [!IMPORTANT]

--- a/windows-driver-docs-pr/devtest/systematic-low-resource-simulation.md
+++ b/windows-driver-docs-pr/devtest/systematic-low-resource-simulation.md
@@ -7,19 +7,17 @@ ms.localizationpriority: medium
 
 # Systematic low resources simulation
 
->[!Note]
-> **This check is deprecated starting in Windows 10 Insider Preview Build 19042 and above**
 The Systematic low resources simulation option injects resource failures in kernel mode drivers. This option penetrates driver error handling paths. Testing these paths has historically been very difficult. The Systematic low resources simulation option injects resource failures in a predictable manner, which makes the issues it finds reproducible. Because the error paths are easy to reproduce, it also makes it easy to verify fixes to these issues.
 
 To help you determine the root cause of the error, a debugger extension is provided that can tell you exactly which failures have been injected and in what order.
 
 **Caution**  This option is not intended for use when you are verifying all (or a large collection of) drivers on a computer. This option should be used only when you are doing targeted testing of individual drivers or their attached filter drivers. Using this option on a large number of drivers at the same time could cause unpredictable results, and could force crashes in components unrelated to the driver(s) you are testing.
 
- 
+
 
 **Note**  For Windows 8.1, the [Stack Based Failure Injection](stack-based-failure-injection.md) feature, which was available in the WDK 8, has been integrated into Driver Verifier. On computers running Windows 8.1, use the Systematic low resources simulation option.
 
- 
+
 
 When the Systematic low resources simulation option is enabled on a specific driver, it intercepts some calls from that driver to the kernel and Ndis.sys. Systematic low resources simulation looks at the call stack—specifically, at the portion of the call stack that comes from the driver it is enabled on. If this is the first time it has ever seen that stack, it will fail the call according to the semantics of that call. Otherwise, if it has seen that call before, it will pass it through untouched. Systematic low resources simulation contains logic to deal with the fact that a driver can be loaded and unloaded multiple times. It will recognize that a call stack is the same even if the driver is reloaded into a different memory location.
 
@@ -30,6 +28,14 @@ You can activate the Systematic low resources simulation feature for one or more
 
 -   **At the command line**
 
+    **Windows 11**
+
+    At the command line, Systematic low resources simulation is represented by **verifier /rc 19 36** (including the required DIF mode) or **verifier /dif 19**.
+
+    The feature will be active after the next boot, or immediately if **/now** is added to the command string.
+
+    **Windows 10 and below**
+
     At the command line, Systematic low resources simulation is represented by **verifier /flags 0x040000** (Bit 18). To Systematic low resources simulation, use a flag value of 0x040000 or add 0x040000 to the flag value. For example:
 
     ```
@@ -37,6 +43,8 @@ You can activate the Systematic low resources simulation feature for one or more
     ```
 
     The feature will be active after the next boot.
+
+    **General**
 
     When you enable the Systematic low resources simulation option, you can use the **/faultssystematic** *OPTION* command line option to further control the Systematic low resources simulation.
 
@@ -103,7 +111,7 @@ You can activate the Systematic low resources simulation feature for one or more
     </tbody>
     </table>
 
-     
+
 
 -   **Using Driver Verifier Manager**
 
@@ -116,7 +124,7 @@ You can activate the Systematic low resources simulation feature for one or more
 ## <span id="Debugging_bug_checks_caused_by_Systematic_low_resources_simulation"></span><span id="debugging_bug_checks_caused_by_systematic_low_resources_simulation"></span><span id="DEBUGGING_BUG_CHECKS_CAUSED_BY_SYSTEMATIC_LOW_RESOURCES_SIMULATION"></span>Debugging bug checks caused by Systematic low resources simulation
 
 
-Most of the issues found with Systematic low resources simulation result in bug checks. To help determine the cause of these code bugs, the [Windows Debugging](../debugger/index.md) tools for Windows 8.1 provides the debugger extension (kdexts.dll) and the necessary symbols.
+Most of the issues found with Systematic low resources simulation result in bug checks. To help determine the cause of these code bugs, the [Debugging Tools for Windows](../debugger/index.md) provide the debugger extension (kdexts.dll) and the necessary symbols.
 
 **To run the debugger extension**
 
@@ -128,5 +136,5 @@ Most of the issues found with Systematic low resources simulation result in bug 
 
 This will dump information to your debugger showing the call stacks from the most recent failures injected.
 
- 
+
 

--- a/windows-driver-docs-pr/devtest/systematic-low-resource-simulation.md
+++ b/windows-driver-docs-pr/devtest/systematic-low-resource-simulation.md
@@ -30,7 +30,7 @@ You can activate the Systematic low resources simulation feature for one or more
 
     **Windows 11**
 
-    At the command line, Systematic low resources simulation is represented by **verifier /rc 19 36** (including the required DIF mode) or **verifier /dif 19**.
+    At the command line, Systematic low resources simulation is represented by **verifier /rc 19 36** or **verifier /dif 19**, both of which include the required DIF mode.
 
     The feature will be active after the next boot, or immediately if **/now** is added to the command string.
 

--- a/windows-driver-docs-pr/devtest/using-volatile-settings.md
+++ b/windows-driver-docs-pr/devtest/using-volatile-settings.md
@@ -35,7 +35,7 @@ As of Windows 11, only the following flags can be used with volatile:
 ```
 
 > [!NOTE]
-> Many other flags in Windows 11 may be enabled without reboot using the **/now** [Verifier Command](verifier-command-line.md).
+> A number of other flags in Windows 11 may be enabled without reboot using the **/now** command. The supported flags are described in [Verifier Command](verifier-command-line.md).
 
 As of Windows 10, only the following flags can be used with volatile:
 

--- a/windows-driver-docs-pr/devtest/using-volatile-settings.md
+++ b/windows-driver-docs-pr/devtest/using-volatile-settings.md
@@ -20,7 +20,7 @@ However, you can activate and deactivate some options without rebooting. These a
 This section explains the volatile settings and how to use them on the versions of Driver Verifier included in different versions of Windows.
 
 > [!NOTE]
-> This option will be deprecated in a future release of Windows. A replacement option will be provided.
+> This option will be deprecated in a future release of Windows. A replacement option for Windows 11 is provided with the **/now** [Verifier Command](verifier-command-line.md).
 
 ### Changing Options Without Rebooting
 
@@ -30,9 +30,12 @@ As of Windows 11, only the following flags can be used with volatile:
 0x00000004 (bit  2) - Randomized low resources simulation
 0x00000020 (bit  5) - Deadlock detection
 0x00000080 (bit  7) - DMA checking
-0x00000200 (bit  9) - Force pending I/O requests 
-0x00000400 (bit 10) - IRP logging 
+0x00000200 (bit  9) - Force pending I/O requests
+0x00000400 (bit 10) - IRP logging
 ```
+
+> [!NOTE]
+> Many other flags in Windows 11 may be enabled without reboot using the **/now** [Verifier Command](verifier-command-line.md).
 
 As of Windows 10, only the following flags can be used with volatile:
 
@@ -109,7 +112,7 @@ To add or remove a driver from the volatile list, use the **/volatile /adddriver
     verifier /volatile /flags 0x20
     ```
 
-   
+
 -   To turn off all Driver Verifier options:
 
     You cannot stop the verification of a driver that is currently loaded without rebooting. However, you can use the following command syntax to deactivate all of the Driver Verifier options without rebooting, thereby minimizing the overhead until the next reboot.
@@ -121,7 +124,7 @@ To add or remove a driver from the volatile list, use the **/volatile /adddriver
     Driver Verifier continues to monitor the driver using the options in the [Automatic Checks](automatic-checks.md) feature, which cannot be turned off, but the overhead is reduced to approximately ten percent of the overhead of a typical verification.
 
 
-### Configuring Volatile Settings by Using Driver Verifier Manager 
+### Configuring Volatile Settings by Using Driver Verifier Manager
 
 **To view the Driver Verifier features that are currently active, or to change the volatile settings**
 
@@ -143,13 +146,13 @@ To add or remove a driver from the volatile list, use the **/volatile /adddriver
 
 Driver Verifier Manager shows three possible status values for drivers shown on the **Current settings and verified drivers (run time information)** screen. The possible status values are as follows:
 
-<span id="Loaded"></span><span id="loaded"></span><span id="LOADED"></span>**Loaded**  
+<span id="Loaded"></span><span id="loaded"></span><span id="LOADED"></span>**Loaded**
 The driver is currently loaded and is being verified.
 
-<span id="Unloaded"></span><span id="unloaded"></span><span id="UNLOADED"></span>**Unloaded**  
+<span id="Unloaded"></span><span id="unloaded"></span><span id="UNLOADED"></span>**Unloaded**
 The driver was loaded and verified at least once since the last boot, but is currently not loaded.
 
-<span id="Never_Loaded"></span><span id="never_loaded"></span><span id="NEVER_LOADED"></span>**Never Loaded**  
+<span id="Never_Loaded"></span><span id="never_loaded"></span><span id="NEVER_LOADED"></span>**Never Loaded**
 Driver Verifier was instructed to verify this driver, but the driver has not been loaded since this request. This can indicate that the driver is loaded on demand and has not yet been required in this session. It might also indicate that a nonexistent driver was requested for verification, or that a driver image file has been corrupted.
 
 ## Related topics
@@ -159,9 +162,9 @@ Driver Verifier was instructed to verify this driver, but the driver has not bee
 
 [Controlling Driver Verifier](controlling-driver-verifier.md)
 
- 
 
- 
+
+
 
 
 


### PR DESCRIPTION
Based on feedback from developers, this PR includes the following changes:
- Add links from the legacy volatile settings page to the Verifier command syntax page, which contains information about the `/now` command.
- Add a section for Windows 11 changes to the "What's New" page. Currently the only change in this section is informing about the `/now` command.
- Remove an outdated deprecation notice on the systematic fault injection page. Autofail is still actively supported.