### PR TITLE
Remove Rdr prefix from CleanupTransportConnection

### DIFF
--- a/windows-driver-docs-pr/debugger/manually-walking-a-stack.md
+++ b/windows-driver-docs-pr/debugger/manually-walking-a-stack.md
@@ -193,7 +193,7 @@ rdr!__strnicmp+0xa8:
 fe68204e 0000             add     [eax],al 
 ```
 
-Based on this, it appears that **RdrReconnectConnection** called **CleanupTransportConnection**, to **RdrTdiDisconnect**, to **ZwCloseObjectAuditAlarm**, to **KiSystemServiceExit**. The other functions on the stack are probably leftover portions of previously active stacks.
+Based on this, it appears that **RdrReconnectConnection** called **CleanupTransportConnection**, to **RdrTdiDisconnect**, to **ZwCloseObjectAuditAlarm**, to **KiServiceExit**. The other functions on the stack are probably leftover portions of previously active stacks.
 
 In this case, the stack trace worked properly. Following is the actual stack trace to check the answer:
 

--- a/windows-driver-docs-pr/debugger/manually-walking-a-stack.md
+++ b/windows-driver-docs-pr/debugger/manually-walking-a-stack.md
@@ -193,7 +193,7 @@ rdr!__strnicmp+0xa8:
 fe68204e 0000             add     [eax],al 
 ```
 
-Based on this, it appears that **RdrReconnectConnection** called **RdrCleanupTransportConnection**, to **RdrTdiDisconnect**, to **ZwCloseObjectAuditAlarm**, to **KiSystemServiceExit**. The other functions on the stack are probably leftover portions of previously active stacks.
+Based on this, it appears that **RdrReconnectConnection** called **CleanupTransportConnection**, to **RdrTdiDisconnect**, to **ZwCloseObjectAuditAlarm**, to **KiSystemServiceExit**. The other functions on the stack are probably leftover portions of previously active stacks.
 
 In this case, the stack trace worked properly. Following is the actual stack trace to check the answer:
 


### PR DESCRIPTION
As it appears in the disassembly, there is no `Rdr` prefix for the `_CleanupTransportConnection` function in the `rdr` module.

See the following (and other) disassembly snippets:
```
...
rdr!_RdrTdiDisconnect+0x56
rdr!_CleanupTransportConnection+0x64
rdr!_RdrReconnectConnection+0x1b6
...
```
and
```
...
rdr!_CleanupTransportConnection+0x5f:
fe6b2bff e854e4feff       call    rdr!_RdrTdiDisconnect (fe6a1058)
kd> u fe685968-5 l1      //  looks good, call to immediately above
rdr!_RdrReconnectConnection+0x1b1:
fe685963 e838d20200       call    rdr!_CleanupTransportConnection (fe6b2ba0)
...
```