### PR TITLE
Remove a duplicated link from "Standard Debugging Techniques" page

### DIFF
--- a/windows-driver-docs-pr/debugger/standard-debugging-techniques.md
+++ b/windows-driver-docs-pr/debugger/standard-debugging-techniques.md
@@ -46,7 +46,6 @@ This section discusses standard debugging techniques that you can apply across d
 -   [Debugging a Failed Driver Unload](debugging-a-failed-driver-unload.md)
 -   [Reading Bug Check Callback Data](reading-bug-check-callback-data.md)
 -   [Debugging a User-Mode Failure with KD](debugging-a-user-mode-failure-with-kd.md)
--   [Crashing and Rebooting the Target Computer](crashing-and-rebooting-the-target-computer.md)
 -   [Mapping Driver Files](mapping-driver-files.md)
 -   [Messages from the Target](messages-from-the-target.md)
 


### PR DESCRIPTION
[Standard Debugging Techniques](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/standard-debugging-techniques) page has two identical links to [Crashing and Rebooting the Target Computer](crashing-and-rebooting-the-target-computer.md) page (at line 36 and 49 in standard-debugging-techniques.md). This pull request removes the second one to avoid the confusion.