### PR TITLE
Revising the documentation for conditional breakpoints to use new syntax

### DIFF
--- a/windows-driver-docs-pr/debugger/-echo--echo-comment-.md
+++ b/windows-driver-docs-pr/debugger/-echo--echo-comment-.md
@@ -57,10 +57,10 @@ Specifies the text to display. You can also enclose *String* in quotation marks 
 
 The **.echo** command causes the debugger to display *String* immediately after you enter the command.
 
-An **.echo** command is ended if the debugger encounters a semicolon (unless the semicolon occurs within a quoted string). This restriction enables you to use **.echo** in complex constructions such as [conditional breakpoints](setting-a-conditional-breakpoint.md), as the following example shows.
+An **.echo** command is ended if the debugger encounters a semicolon (unless the semicolon occurs within a quoted string). This restriction enables you to use **.echo** in more complex constructions such as with the [j (Execute If - Else)](j--execute-if-else-.md) command, as the following example shows.
 
 ```dbgcmd
-0:000> bp `:143` "j (poi(MyVar)>5) '.echo MyVar Too Big'; '.echo MyVar Acceptable; gc' " 
+0:000> j (poi(MyVar)>5) '.echo MyVar Too Big'; '.echo MyVar Acceptable;
 ```
 
 The **.echo** command also provides an easy way for users of debugging servers and debugging clients to communicate with one another. For more information about this situation, see [Controlling a Remote Debugging Session](controlling-a-remote-debugging-session.md).

--- a/windows-driver-docs-pr/debugger/bp--bu--bm--set-breakpoint-.md
+++ b/windows-driver-docs-pr/debugger/bp--bu--bm--set-breakpoint-.md
@@ -94,10 +94,7 @@ bp /w "@$scriptContents.myFunc(localVariable)" @rip
 
 For more information on debugger objects, see [dx (Display Debugger Object Model Expression)](dx--display-visualizer-variables-.md).
 
-> [!NOTE] 
-> The /w option is experimental and requires the latest version of the debugger. 
-
-
+For more information about conditional breakpoints, see [Setting a Conditional Breakpoint](setting-a-conditional-breakpoint.md).
 
 <span id="_______Address______"></span><span id="_______address______"></span><span id="_______ADDRESS______"></span> *Address*   
 Specifies the first byte of the instruction where the breakpoint is set. If you omit *Address*, the current instruction pointer is used. For more information about the syntax, see [Address and Address Range Syntax](address-and-address-range-syntax.md).

--- a/windows-driver-docs-pr/debugger/gc--go-from-conditional-breakpoint-.md
+++ b/windows-driver-docs-pr/debugger/gc--go-from-conditional-breakpoint-.md
@@ -21,7 +21,7 @@ The **gc** command resumes execution from a conditional breakpoint in the same f
 gc
 ```
 
-While this command is no longer as useful for conditional breakpoints, it can still be useful for breakpoints used for tracing when a break into the debugger is not actually desired. For instance, a breakpoint could be written that looks like this:
+While this command is no longer as useful for conditional breakpoints, it can still be used for breakpoints that do logging or some other activity without breaking into the debugger. For instance, a breakpoint could be written that looks like this:
 
 ```dbgcmd
 bp module!myFunction ".echo myFunction executed; gc"

--- a/windows-driver-docs-pr/debugger/gc--go-from-conditional-breakpoint-.md
+++ b/windows-driver-docs-pr/debugger/gc--go-from-conditional-breakpoint-.md
@@ -15,11 +15,20 @@ ms.localizationpriority: medium
 # gc (Go from Conditional Breakpoint)
 
 
-The **gc** command resumes execution from a conditional breakpoint in the same fashion that was used to hit the breakpoint (stepping, tracing, or freely executing).
+The **gc** command resumes execution from a conditional breakpoint in the same fashion that was used to hit the breakpoint (stepping, tracing, or freely executing). This only applies to the older style of conditional breakpoints using a "j (Condition) ..." style expression, rather than the simpler "/w" style conditional breakpoint. For more information, see [setting a conditional breakpoint](setting-a-conditional-breakpoint.md).
 
 ```dbgcmd
 gc
 ```
+
+While this command is no longer as useful for conditional breakpoints, it can still be useful for breakpoints used for tracing when a break into the debugger is not actually desired. For instance, a breakpoint could be written that looks like this:
+
+```dbgcmd
+bp module!myFunction ".echo myFunction executed; gc"
+```
+
+If a normal "g" command were used instead, the program would continue execution when stepping over "myFunction", instead of simply printing the message and continuing the step operation.
+
 
 ### <span id="Environment"></span><span id="environment"></span><span id="ENVIRONMENT"></span>Environment
 
@@ -52,9 +61,9 @@ For an overview of related commands, see [Controlling the Target](controlling-th
 
 ## Remarks
 
-When a [conditional breakpoint](setting-a-conditional-breakpoint.md) includes an execution command at the end, this should be the **gc** command.
+When a [conditional breakpoint](setting-a-conditional-breakpoint.md) using a "j (Condition) ..." expression includes an execution command at the end, this should be the **gc** command.
 
-For example, the following is a proper conditional breakpoint formulation:
+For example, the following is an example conditional breakpoint:
 
 ```dbgcmd
 0:000> bp Address "j (Condition) 'OptionalCommands'; 'gc' " 

--- a/windows-driver-docs-pr/debugger/j--execute-if---else-.md
+++ b/windows-driver-docs-pr/debugger/j--execute-if---else-.md
@@ -82,7 +82,7 @@ You can also use the **j** command inside other commands. For example, you can u
 0:000> bp `mysource.cpp:143` "j (poi(MyVar)>0n20) ''; 'gc' "
 ```
 
-For more information about the syntax for conditional breakpoints, see [Setting a Conditional Breakpoint](setting-a-conditional-breakpoint.md).
+This style of conditional breakpoint is no longer recommended, as a simpler form is now available in the debugger. For more information about the syntax of conditional breakpoints, see [Setting a Conditional Breakpoint](setting-a-conditional-breakpoint.md).
 
 ## <span id="see_also"></span>See also
 

--- a/windows-driver-docs-pr/debugger/setting-a-conditional-breakpoint.md
+++ b/windows-driver-docs-pr/debugger/setting-a-conditional-breakpoint.md
@@ -14,7 +14,44 @@ Conditional breakpoints in WinDbg and other Windows debuggers are useful when yo
 ## <span id="ddk_setting_a_conditional_breakpoint_dbg"></span><span id="DDK_SETTING_A_CONDITIONAL_BREAKPOINT_DBG"></span>
 
 
-A conditional breakpoint is created by combining a breakpoint command with either the [**j (Execute If - Else)**](j--execute-if---else-.md) command or the [**.if**](-if.md) token, followed by the [**gc (Go from Conditional Breakpoint)**](gc--go-from-conditional-breakpoint-.md) command. This breakpoint causes a break to occur only if a specific condition is satisfied.
+A conditional breakpoint is created with the "/w" parameter to the [**bp (Set Breakpoint)**](bp--bu--bm--set-breakpoint-.md) or other breakpoint command. The basic syntax of the command is:
+
+```dbgcmd
+0:000> bp /w "(Condition)" Address
+```
+
+The breakpoint will only cause a break into the debugger when the specified condition is true. The "w" is an abbreviation for "when". The condition expression can be anything that can be used with the [**dx (Display Debugger Object Model Expression)**](dx--display-visualizer-variables-.md) command. This includes most C++ style expressions including comparisons, arithmetic, pointer operations, and others. For instance, a basic conditional breakpoint that only breaks in when a variable is more than 20 could be written as:
+
+```dbgcmd
+0:000> bp /w "MyVar > 20" `mysource.cpp:143`
+```
+
+Since the condition is evaluated using the debugger object model, you can also take advantage of things like NatVis support. For instance, assuming myVec is a std::vector<int>, you could create a condition such as:
+
+```dbgcmd
+0:000> bp /w "myVec.Count() == 4" `mysource.cpp:143`
+```
+
+This will break in when line 143 of mysource.cpp is executed while the myVec variable has 4 elements.
+
+Beyond natvis, you can also invoke a JavaScript function. If you load a script using the WinDbg script window or the [**.scriptload (Load Script)**](-scriptload--load-script-.md) command which contains a function called "myFunc", you could set a breakpoint like this:
+
+```dbgcmd
+0:000> bp /w "@$scriptContents.myFunc()" `mysource.cpp:143`
+```
+
+For more information about writing JavaScript functions and extensions in the debugger, see [JavaScript Debugger Scripting](javascript-debugger-scripting.md)
+
+While higher level expressions are typically the most useful, it's also possible to evaluate registers using these expresions. For instance, you could create a breakpoint that only triggers when the stack pointer reaches some threshold:
+
+```dbgcmd
+0:000> bp /w "@esp < 0x6ff9f8" `mysource.cpp:143`
+```
+
+
+### <span id="legacy_conditional_breakpoint_syntax"></span>Legacy conditional breakpoint syntax
+
+Before the availability of the "/w" parameter to the breakpoint commands, the recommended way to set conditional breakpoints was to use the [**j (Execute If - Else)**](j--execute-if---else-.md) command or the [**.if**](-if.md) token, followed by the [**gc (Go from Conditional Breakpoint)**](gc--go-from-conditional-breakpoint-.md) command. While these methods of setting conditional breakpoints are no longer recommended, they do still function and you may see this syntax referenced in other sources.
 
 The basic syntax for a conditional breakpoint using the **j** command is as follows:
 
@@ -27,111 +64,3 @@ The basic syntax for a conditional breakpoint using the **.if** token is as foll
 ```dbgcmd
 0:000> bp Address ".if (Condition) {OptionalCommands} .else {gc}"
 ```
-
-Conditional breakpoints are best illustrated with an example. The following command sets a breakpoint at line 143 of the Mysource.cpp source file. When this breakpoint is hit, the variable **MyVar** is tested. If this variable is less than or equal to 20, execution continues; if it is greater than 20, execution stops.
-
-```dbgcmd
-0:000> bp `mysource.cpp:143` "j (poi(MyVar)>0n20) ''; 'gc' " 
-0:000> bp `mysource.cpp:143` ".if (poi(MyVar)>0n20) {} .else {gc}"
-```
-
-The preceding command has a fairly complicated syntax that contains the following elements:
-
--   The [**bp (Set Breakpoint)**](bp--bu--bm--set-breakpoint-.md) command sets breakpoints. Although the preceding example uses the bp command, you could also use the **bu (Set Unresolved Breakpoint)** command. For more information about the differences between **bp** and **bu**, and for a basic introduction to breakpoints, see [Using Breakpoints](using-breakpoints.md).
-
--   Source line numbers are specified by using grave accents ( **\`** ). For details, see [Source Line Syntax](source-line-syntax.md).
-
--   When the breakpoint is hit, the command in straight quotation marks ( **"** ) is executed. In this example, this command is a [**j (Execute If - Else)**](j--execute-if---else-.md) command or an [**.if**](-if.md) token, which tests the expression in parentheses.
-
--   In the source program, **MyVar** is an integer. If you are using C++ expression syntax, **MyVar** is interpreted as an integer. However, in this example (and in the default debugger configuration), MASM expression syntax is used. In a MASM expression, **MyVar** is treated as an address. Thus, you need to use the **poi** operator to dereference it. (If your variable actually is a C pointer, you will need to dereference it twice--for example, **poi(poi(MyPtr))**.) The **0n** prefix specifies that this number is decimal. For syntax details, see [MASM Numbers and Operators](masm-numbers-and-operators.md).
-
--   The expression in parentheses is followed by two commands, surrounded by single quotation marks ( **'** ) for the **j** command and curly brackets ( {} ) for the **.if** token. If the expression is true, the first of these commands is executed. In this example, there is no first command, so command execution will end and control will remain with the debugger. If the expression in parentheses is false, the second command will execute. The second command should almost always be a [**gc (Go from Conditional Breakpoint)**](gc--go-from-conditional-breakpoint-.md) command, because this command causes execution to resume in the same manner that was occurring before the breakpoint was hit (stepping, tracing, or free execution).
-
-If you want to see a message each time the breakpoint is passed or when it is finally hit, you can use additional commands in the single quotation marks or curly brackets. For example:
-
-```dbgcmd
-0:000> bp `:143` "j (poi(MyVar)>5) '.echo MyVar Too Big'; '.echo MyVar Acceptable; gc' " 
-0:000> bp `:143` ".if (poi(MyVar)>5) {.echo MyVar Too Big} .else {.echo MyVar Acceptable; gc} " 
-```
-
-These comments are especially useful if you have several such breakpoints running at the same time, because the debugger does not display its standard "Breakpoint *n* Hit" messages when you are using a command string in the **bp** command.
-
-### <span id="Conditional_Breakpoint_Based_on_String_Comparison"></span><span id="conditional_breakpoint_based_on_string_comparison"></span><span id="CONDITIONAL_BREAKPOINT_BASED_ON_STRING_COMPARISON"></span>Conditional Breakpoint Based on String Comparison
-
-In some situations you might want to break into the debugger only if a string variable matches a pattern. For example, suppose you want to break at kernel32!CreateEventW only if the *lpName* argument points to a string that matches the pattern "Global\*". The following example shows how to create the conditional breakpoint.
-
-```dbgcmd
-bp kernel32!CreateEventW "$$<c:\\commands.txt"
-```
-
-The preceding [**bp**](bp--bu--bm--set-breakpoint-.md) command creates a breakpoint based on conditions and optional commands that are in a script file named commands.txt. The script file contains the following statements.
-
-```dbgcmd
-.if (@r9 != 0) { as /mu ${/v:EventName} @r9 } .else { ad /q ${/v:EventName} }
-.if ($spat(@"${EventName}", "Global*") == 0)  { gc } .else { .echo EventName }
-```
-
-The *lpName* argument passed to the **CreateEventW** function is the fourth argument, so it is stored in the r9 register (x64 processor). The script performs the following steps:
-
-1.  If *lpName* is not NULL, use [**as**](as--as--set-alias-.md) and [**${}**](-------alias-interpreter-.md) to create an alias named EventName. Assign to EventName the null-terminated Unicode string beginning at the address pointed to by *lpName*. On the other hand, if *lpName* is NULL, use [**ad**](ad--delete-alias-.md) to delete any existing alias named EventName.
-
-2.  Use [**$spat**](masm-numbers-and-operators.md) to compare the string represented by EventName to the pattern "Global\*". If the string does not match the pattern, use [**gc**](gc--go-from-conditional-breakpoint-.md) to continue without breaking. If the string does match the pattern, break and display the string represented by EventName.
-
-**Note**  [**$spat**](masm-numbers-and-operators.md) performs a case-insensitive match.
-
-**Note**  The ampersand ( @ ) character in $spat(@"${EventName}" specifies that the string represented by EventName is to be interpreted literally; that is, a backslash ( \\ ) is treated as a backslash rather than an escape character.
-
-### <span id="conditional_breakpoints_and_register_sign_extension"></span><span id="CONDITIONAL_BREAKPOINTS_AND_REGISTER_SIGN_EXTENSION"></span>Conditional Breakpoints and Register Sign Extension
-
-You can set a breakpoint that is conditional on a register value.
-
-The following command will break at the beginning of the **myFunction** function if the **eax** register is equal to 0xA3:
-
-```dbgcmd
-0:000> bp mydriver!myFunction "j @eax = 0xa3  '';'gc'" 
-0:000> bp mydriver!myFunction ".if @eax = 0xa3  {} .else {gc}"
-```
-
-However, the following similar command will not necessarily break when **eax** equals 0xC0004321:
-
-```dbgcmd
-0:000> bp mydriver!myFunction "j @eax = 0xc0004321  '';'gc'" 
-0:000> bp mydriver!myFunction ".if @eax = 0xc0004321  {} .else {gc}"
-```
-
-The reason the preceding command will fail is that the MASM expression evaluator sign-extends registers whose high bit equals one. When **eax** has the value 0xC0004321, it will be treated as 0xFFFFFFFF\`C0004321 in computations--even though **eax** will still be displayed as 0xC0004321. However, the numeral **0xc0004321** is sign-extended in kernel mode, but not in user mode. Therefore, the preceding command will not work properly in user mode. If you mask the high bits of **eax**, the command will work properly in kernel mode--but now it will fail in user mode.
-
-You should formulate your commands defensively against sign extension in both modes. In the preceding command, you can make the command defensive by masking the high bits of a 32-bit register by using an AND operation to combine it with 0x00000000\`FFFFFFFF and by masking the high bits of a numeric constant by including a grave accent ( **\`** ) in its syntax.
-
-The following command will work properly in user mode and kernel mode:
-
-```dbgcmd
-0:000> bp mydriver!myFunction "j (@eax & 0x0`ffffffff) = 0x0`c0004321  '';'gc'" 
-0:000> bp mydriver!myFunction ".if (@eax & 0x0`ffffffff) = 0x0`c0004321  {} .else {gc}"
-```
-
-For more information about which numbers are sign-extended by the debugger, see [Sign Extension](sign-extension.md).
-
-### <span id="conditional_breakpoints_in_windbg"></span><span id="CONDITIONAL_BREAKPOINTS_IN_WINDBG"></span>Conditional Breakpoints in WinDbg
-
-In WinDbg, you can create a conditional breakpoint by selecting [Breakpoints](edit---breakpoints.md) from the **Edit** menu, entering a new breakpoint address into the **Command** box, and entering a condition into the **Condition** box.
-
-For example, typing **mymod!myFunc+0x3A** into the **Command** box and **myVar &lt; 7** into the **Condition** box is equivalent to issuing the following command:
-
-```dbgcmd
-0:000> bu mymod!myFunc+0x3A "j(myVar<7) '.echo "Breakpoint hit, condition myVar<7"'; 'gc'" 
-0:000> bu mymod!myFunc+0x3A ".if(myVar<7) {.echo "Breakpoint hit, condition myVar<7"} .else {gc}" 
-```
-
-### <span id="restrictions_on_conditional_breakpoints"></span><span id="RESTRICTIONS_ON_CONDITIONAL_BREAKPOINTS"></span>Restrictions on Conditional Breakpoints
-
-If you are [controlling the user-mode debugger from the kernel debugger](controlling-the-user-mode-debugger-from-the-kernel-debugger.md), you cannot use conditional breakpoints or any other breakpoint command string that contains the [**gc (Go from Conditional Breakpoint)**](gc--go-from-conditional-breakpoint-.md) or [**g (Go)**](g--go-.md) commands. If you use these commands, the serial interface might not be able to keep up with the number of breakpoint passes, and you will be unable to break back into CDB.
-
- 
-
- 
-
-
-
-
-


### PR DESCRIPTION
This is a decent size rework of our documentation for conditional breakpoints. The old style of conditional breakpoints is unwieldy and not nearly as useful as the new syntax using "/w". I also tried to hit a few of the places where we referenced the old syntax.