### PR TITLE
Update privacy-shutter-notification.md

### DIFF
--- a/windows-driver-docs-pr/stream/privacy-shutter-notification.md
+++ b/windows-driver-docs-pr/stream/privacy-shutter-notification.md
@@ -27,6 +27,8 @@ The **KSEVENT** is issued by using the same Set GUID and Id as the **KSPROPERTY*
 
 To clarify what is shown in the diagram above, the OS is expecting the AVS driver to implement mechanism, if the driver developer chooses to support this feature, to get and listen state changes that the shutter sensor is generating. The OS queries the state via the **KSPROPERTY** get method and issue a waiting **KSEVENT** that the driver will signal when the shutter state is changed. The shutter state change should not prevent the camera from functioning, for example, to cause an error situation.
 
+**NOTE:** If the AVS driver supports this feature but the underlying hardware does not, the AVS driver shall return not supported error when the OS issues the **KSEVENT** registration.
+
 ## KSPROPERTY
 
 ### Usage Summary Table (KSPROPERTY)


### PR DESCRIPTION
Added a phrase to describe what the AVS driver should do if underlying HW does not support the privacy shutter.