### PR TITLE
repair DeviceProperties_RunDLL typedef example

### DIFF
--- a/windows-driver-docs-pr/install/invoking-a-device-properties-dialog-box-programmatically-in-an-install.md
+++ b/windows-driver-docs-pr/install/invoking-a-device-properties-dialog-box-programmatically-in-an-install.md
@@ -30,19 +30,19 @@ The following code example shows how to define a *pDeviceProperties* function po
 ```cpp
 #ifdef _UNICODE 
   #define DeviceProperties_RunDLL  "DeviceProperties_RunDLLW"
- typedef void (_stdcall *PDEVICEPROPERTIES)(
+  typedef void (_stdcall *PDEVICEPROPERTIES)(
     HWND hwndStub,
     HINSTANCE hAppInstance,
     LPWSTR lpCmdLine,
- int nCmdShow
-   ;
+    int nCmdShow
+  );
 #else
   #define DeviceProperties_RunDLL  "DeviceProperties_RunDLLA"
- typedef void (_stdcall *PDEVICEPROPERTIES)(
+  typedef void (_stdcall *PDEVICEPROPERTIES)(
     HWND hwndStub,
     HHINSTANCE hAppInstance,
     LPSTR lpCmdLine,
- int nCmdShow
+    int nCmdShow
   );
 #endif
 


### PR DESCRIPTION
It was missing a close-parenthesis, and the indentation was quite inconsistent.