### PR TITLE
Convert em dash to minus in example command flags

### DIFF
--- a/windows-driver-docs-pr/wdf/using-umdf-verifier.md
+++ b/windows-driver-docs-pr/wdf/using-umdf-verifier.md
@@ -30,7 +30,7 @@ Starting in UMDF 2.0, UMDF Verifier issues breakpoints in some cases, and causes
 We strongly recommend doing all development and testing of your driver after enabling [Application Verifier (AppVerif.exe)](../debugger/debugger-download-tools.md) on WUDFHost.exe. Use the following command, attach a debugger and then reboot.
 
 ```cpp
-AppVerif –enable Heaps Exceptions Handles Locks Memory TLS Leak –for WudfHost.exe
+AppVerif -enable Heaps Exceptions Handles Locks Memory TLS Leak -for WudfHost.exe
 ```
 
 Starting in version 2.0 of UMDF, if you run [Application Verifier](../debugger/debugger-download-tools.md) on the driver host process (Wudfhost), UMDF Verifier is automatically enabled for all UMDF 2.0 drivers in that host, as well as all UMDF 2.0 drivers in future driver host processes.


### PR DESCRIPTION
cmd.exe actually converts em dash to minus on paste, mitigating the issue.