### PR TITLE
Update iddcx1.4-updates-for-remote-idds.md

### DIFF
--- a/windows-driver-docs-pr/display/iddcx1.4-updates-for-remote-idds.md
+++ b/windows-driver-docs-pr/display/iddcx1.4-updates-for-remote-idds.md
@@ -24,7 +24,7 @@ An IDD declares it wants to create a remote ID adapter by setting the **IDDCX_AD
 
 ### Installation recommendations for remote IDDs
 
-UMDF allows drivers to control the [device pooling option](../wdf/using-device-pooling-in-umdf-drivers.md) in their INF files, using directives such as **UmdfHostProcessSharing** and **DeviceGroupId**. Due to some lock contention issues, it is highly recommended that remote IDDs set the **UmdfHostProcessSharing** directive to **ProcessSharingDisabled**. This setting will configure the remote IDD for each session to be in its own process.
+UMDF allows drivers to control the [device pooling option](../wdf/using-device-pooling-in-umdf-drivers.md) in their INF files, using directives such as **UmdfHostProcessSharing** and **DeviceGroupId**. Due to some lock contention issues, it is highly recommended that remote IDDs set the **UmdfHostProcessSharing** directive to **ProcessSharingDisabled** and remove any **DeviceGroupId** directives. This setting will configure the remote IDD for each session to be in its own process.
 
 ### Additional restrictions on existing IddCx features for remote IDDs
 


### PR DESCRIPTION
Found out from UMDF team that to use UmdfHostProcessSharing you cannot have DeviceGroupId directives