### PR TITLE
Add some extra wording about the ProcessId parameter.

### DIFF
--- a/windows-driver-docs-pr/ifs/flt-parameters-for-irp-mj-lock-control.md
+++ b/windows-driver-docs-pr/ifs/flt-parameters-for-irp-mj-lock-control.md
@@ -50,10 +50,10 @@ Key value to be assigned to the byte-range lock.
 Starting byte offset within the file of the range to be locked.
 
 **ProcessId**  
-Opaque pointer to the process ID for the process that requested the byte-range lock.
+Opaque pointer to the process object for the process that requested the byte-range lock.  This is only valid for FastIO requests.  This field should therefore never be set when using this structure to issue a lock control function.
 
 **FailImmediately**  
-Boolean value specifying whether the lock request should fail if the lock cannot be granted immediately. This member is set to **FALSE** if the requesting thread can be put into a wait state until the request is granted or **TRUE** if it cannot.
+Boolean value specifying whether the lock request should fail if the lock cannot be granted immediately. This member is set to **FALSE** if the requesting thread can be put into a wait state until the request is granted or **TRUE** if it cannot.  
 
 **ExclusiveLock**  
 Boolean value specifying whether an exclusive lock is requested. This member is set to **TRUE** if an exclusive lock is requested or **FALSE** if a shared lock is requested.


### PR DESCRIPTION
The header file says 
```
        PEPROCESS ProcessId;        //  Only meaningful for FastIo locking operations.
        BOOLEAN FailImmediately;    //  Only meaningful for FastIo locking operations.
        BOOLEAN ExclusiveLock;      //  Only meaningful for FastIo locking operations.
```
From which several observations:
* ProcessId is a process _object_ not a ID.  Fixed in this PR
* ProcessId should never be set (because you cannot tell whether this is a fastio operation).  Fixed in this PR
* It is therefore impossible to send an IRP_MJ_LOCK_REQUEST on behalf of another process (for instance in a posted thread).  This is because you cannot set the ThreadID in the cbd.  Not addressed in this PR because I don't know how to.
* FailImmediately and ExclusiveLock should not be set (for the same reason as ProcessID).  Not fixed in this PR because in my experimentation you can set them so the header file might be wrong.

I sense that this PR needs more attention before its ready for prime time.