### PR TITLE
Update ksproperty-cameracontrol-extended-backgroundsegmentation.md to use match with SDK

### DIFF
--- a/windows-driver-docs-pr/stream/background-segmentation-portrait-mode-eye-gaze-stare-mode-driver-sample.md
+++ b/windows-driver-docs-pr/stream/background-segmentation-portrait-mode-eye-gaze-stare-mode-driver-sample.md
@@ -1,12 +1,12 @@
 ---
-title: Background segmentation portrait mode and eye gaze stare mode driver sample
-description: Provides an example implementation of background segmentation portrait mode and eye gaze stare mode controls in a camera driver.
+title: Background segmentation shallow focus mode and eye gaze stare mode driver sample
+description: Provides an example implementation of background segmentation shallow focus mode and eye gaze stare mode controls in a camera driver.
 ms.date: 05/16/2022
 ---
 
-# Background segmentation portrait mode and eye gaze stare mode driver sample
+# Background segmentation shallow focus mode and eye gaze stare mode driver sample
 
-This is an example implementation of background segmentation portrait mode and eye gaze stare mode, two new bit fields being introduced in Windows 11, version 22H2.
+This is an example implementation of background segmentation shallow focus mode and eye gaze stare mode, two new bit fields being introduced in Windows 11, version 22H2.
 
 These controls are typically implemented in C++, as part of the user mode extension of an Avstream camera driver in Device MFT.
 
@@ -16,28 +16,35 @@ These controls are typically implemented in C++, as part of the user mode extens
 ## SampleMFT.h
 
 ```cpp
-Class CSampleMFT //Snipped from SampleDeviceMFT Implementation 
-{ 
-... 
-Private: 
-... 
-    VOID SetBackgroundSegmentationPortraitMode(BOOLEAN enabled) 
-    { 
-        m_backgroundSegmentationPortraitModeEnabled = enabled; 
-    } 
-    BOOLEAN GetBackgroundSegmentationPortraitMode() 
-    { 
-        return m_backgroundSegmentationPortraitModeEnabled; 
-    } 
-    VOID SetEyeGazeCorrectionMode(DWORD flags) 
-    { 
-        m_eyeGazeCorrectionMode = flags; 
-    } 
-    DWORD GetEyeGazeCorrectionMode() 
-    { 
-        return m_eyeGazeCorrectionMode; 
-    } 
-    BOOLEAN m_backgroundSegmentationPortraitModeEnabled; 
+Class CSampleMFT //Snipped from SampleDeviceMFT Implementation
+{
+...
+Private:
+...
+    VOID SetBackgroundSegmentationShallowFocus(BOOLEAN enabled)
+    {
+        m_backgroundSegmentationShallowFocusEnabled = enabled;
+    }
+    BOOLEAN GetBackgroundSegmentationShallowFocus()
+    {
+        return m_backgroundSegmentationShallowFocusEnabled;
+    }
+    constexpr ULONGLONG SupportedBackgroundSegmentation()
+    {
+        return  KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR |
+                KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK |
+                KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS;
+    }
+
+    VOID SetEyeGazeCorrectionMode(DWORD flags)
+    {
+        m_eyeGazeCorrectionMode = flags;
+    }
+    DWORD GetEyeGazeCorrectionMode()
+    {
+        return m_eyeGazeCorrectionMode;
+    }
+    BOOLEAN m_backgroundSegmentationShallowFocusEnabled;
     DWORD m_eyeGazeCorrectionMode;
 };
 ```
@@ -45,95 +52,102 @@ Private:
 ## SampleMFT.cpp
 
 ```cpp
-// KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE
+// KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS
 HRESULT CSampleMft::BackgroundSegmentationHandler(
-    _In_       PKSPROPERTY property,
-    _In_       LPVOID      data,
-    _In_       ULONG       outputBufferLength,
-    _Inout_    PULONG      bytesReturned)
+    _In_ PKSPROPERTY property,
+    _In_ LPVOID data,
+    _In_ ULONG outputBufferLength,
+    _Inout_ PULONG bytesReturned)
 {
     *bytesReturned = 0;
     if (property->Flags & KSPROPERTY_TYPE_SET)
     {
         if (outputBufferLength == 0)
-        {  
-            *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE);  
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));  
-        }  
-        else if (outputBufferLength < sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE))  
         {
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));  
+            *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE);
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));
+        }
+        else if (outputBufferLength < sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE))
+        {
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));
         }
         else if (data && outputBufferLength >= sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE))
-        {  
-            PBYTE payload = (PBYTE)data;  
-            PKSCAMERA_EXTENDEDPROP_HEADER extendedHeader = (PKSCAMERA_EXTENDEDPROP_HEADER)payload;  
+        {
+            PBYTE payload = (PBYTE)data;
+            PKSCAMERA_EXTENDEDPROP_HEADER extendedHeader = (PKSCAMERA_EXTENDEDPROP_HEADER)payload;
+            // The extended value is unused for SET with this control, only flags are expected
+            PKSCAMERA_EXTENDEDPROP_VALUE extendedValue = (PKSCAMERA_EXTENDEDPROP_VALUE)(payload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));
+            if (extendedHeader->Flags & ~SupportedBackgroundSegmentation())
+            {
+                RETURN_HR(E_INVALIDARG);
+            }
 
-            // The extended value is unused for SET with this control, only flags are expected  
-            PKSCAMERA_EXTENDEDPROP_VALUE extendedValue = (PKSCAMERA_EXTENDEDPROP_VALUE)(payload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));  
-            switch (extendedHeader->Flags)  
-            {  
-            case KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE:  
-                SetBackgroundSegmentationPortraitMode(true); 
-                SetBackgroundSegmentationBlur(false);  
-                break; 
-            case KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR:  
-                SetBackgroundSegmentationBlur(true);  
-                SetBackgroundSegmentationPortraitMode(false); 
-                break;  
-            case KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK:  
-                SetBackgroundSegmentationMask(true);  
-                break;  
-            case KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF:  
-                SetBackgroundSegmentationBlur(false);  
-                SetBackgroundSegmentationMask(false);  
-                SetBackgroundSegmentationPortraitMode(false); 
-                break;  
-            default:  
-                RETURN_HR(E_INVALIDARG);  
-                break;  
-            }  
-        }  
-        else  
-        {  
-            RETURN_IF_FAILED(E_INVALIDARG);  
-        }  
-    }     
-    else if (property->Flags & KSPROPERTY_TYPE_GET)  
-    {  
-        if (outputBufferLength == 0)  
-        {  
-            *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);  
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));  
-        }  
-        else if (outputBufferLength < sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps))  
-        {  
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));  
-        }  
-        else if (data && outputBufferLength >= sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps)) 
-        {  
-            PBYTE payload = (PBYTE)data;  
-            PKSCAMERA_EXTENDEDPROP_HEADER extendedHeader = (PKSCAMERA_EXTENDEDPROP_HEADER)(payload);  
+            bool shallowFocus = WI_IsFlagSet((extendedHeader->Flags, KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS);
+            bool blur = WI_IsFlagSet((extendedHeader->Flags, KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR);
+            bool mask = WI_IsFlagSet((extendedHeader->Flags, KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK);
 
-            extendedHeader->Capability = KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK | 
-                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR |  
-                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE | 
-                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF;  
+            // If you ask for shallow focus, you must also ask for blur.
+            if (shallowFocus && !blur)
+            {
+                RETURN_HR(E_INVALIDARG);
+            }
+            SetBackgroundSegmentationShallowFocus(shallowFocus);
+            SetBackgroundSegmentationBlur(blur);
+            SetBackgroundSegmentationMask(mask);
+        }
+        else
+        {
+            RETURN_IF_FAILED(E_INVALIDARG);
+        }
+    }
+    else if (property->Flags & KSPROPERTY_TYPE_GET)
+    {
+        if (outputBufferLength == 0)
+        {
+            *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));
+        }
+        else if (outputBufferLength < sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps))
+        {
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(ERROR_MORE_DATA));
+        }
+        else if (data && outputBufferLength >= sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps))
+        {
+            PBYTE payload = (PBYTE)data;
+            PKSCAMERA_EXTENDEDPROP_HEADER extendedHeader = (PKSCAMERA_EXTENDEDPROP_HEADER)(payload);
+            extendedHeader->Capability = KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK |
+                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR |
+                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS |
+                                         KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF;
 
-            extendedHeader->Flags = GetBackgroundSegmentationBlur() ? 
-KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR : (GetBackgroundSegmentationPortraitMode() ? KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PortraitMode : (GetBackgroundSegmentationMask() ? 
-KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK : KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF));
-            extendedHeader->Result = 0;  
-            extendedHeader->Size = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);  
-            extendedHeader->Version = 1;  
+            if (GetBackgroundSegmentationMask())
+            {
+                extendedHeader->Flags |= KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK;
+            }
 
-            PKSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS configCap = (PKSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS)(payload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));  
-            memcpy(configCap, m_configCaps, sizeof(m_configCaps));  
+            if (GetBackgroundSegmentationBlur())
+            {
+                extendedHeader->Flags |= KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR;
+            }
+            else if (GetBackgroundSegmentationShallowFocus())
+            {
+                extendedHeader->Flags |= KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR | KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS;
+            }
+            else
+            {
+                extendedHeader->Flags = KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF;
+            }
+            extendedHeader->Result = 0;
+            extendedHeader->Size = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);
+            extendedHeader->Version = 1;
+            
+            PKSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS configCap = (PKSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS)( payload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER)));
+            memcpy(configCap, m_configCaps, sizeof(m_configCaps));
+            *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);
+        }
+    }
 
-           *bytesReturned = sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(m_configCaps);  
-        }  
-    }  
-    return S_OK;  
+    return S_OK;
 }
 
 // KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
@@ -32,9 +32,9 @@ The following table shows example images of how this works:
 
 | Mode | Example image |
 |--|--|
-| **Shallow Focus & Blur Off** | ![background segmentation portrait blur off.](images/backgroundsegmentation-portrait-blur-off.png) |
-| **Shallow Focus On** | ![background segmentation portrait on.](images/backgroundsegmentation-portrait-on.png) |
-| **Blur On** | ![background segmentation blur on.](images/backgroundsegmentation-blur-on.png) |
+| **Blur Off** | ![background segmentation portrait blur off.](images/backgroundsegmentation-portrait-blur-off.png) |
+| **Shallow Focus On and Blur On** | ![background segmentation portrait on.](images/backgroundsegmentation-portrait-on.png) |
+| **Shallow Focus Off and Blur On** | ![background segmentation blur on.](images/backgroundsegmentation-blur-on.png) |
 
 ## Usage summary table
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
@@ -22,9 +22,9 @@ This property controls an in-stream correction that a driver can perform to enab
 
 Examples of setting KSPROPERTY controls can be found in the [AVStream Camera Sample Driver](https://github.com/microsoft/Windows-driver-samples/tree/master/avstream/avscamera) on GitHub.
 
-## Portrait mode update to KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION control
+##  Update to KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION control
 
-Starting in Windows 11, version 22H2, Portrait mode has been introduced to the existing background segmentation control as an optional capability.
+Starting in Windows 11, version 22H2, Shallow focus mode has been introduced to the existing background segmentation control as an optional capability.
 
  **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** is a new flag added to the KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION control that is used to control the Bokeh (shallow focus mode) on the driver. This is a version of Background blur ([**KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION**](/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)), where the emphasis is less on privacy and more on making the background of the user look like from a higher quality camera with depth of field effect. This visually will make the foreground subject stand out, similar to how portrait mode photography on many mobile phones has become popular.
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
@@ -64,7 +64,7 @@ The following table describes the flag capabilities.
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF** | This is a mandatory capability. When specified, the background segmentation is disabled in the driver. This is the default value. |
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR** | This is an optional capability. When specified, background blur is enabled in the driver and applies to frame if possible. |
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK** | This is an optional capability. When specified, background mask metadata production is enabled in the driver (if possible given the MediaType used as expressed via the set of KSPROPERTY_CAMERACONTROL_EXTENDED_ BACKGROUNDSEGMENTATION_CONFIGCAPS returned in the *Size* field of the KSCAMERA_EXTENDEDPROP_HEADER). Note that this can be supported not only for color cameras but also depth and IR cameras. |
-| **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** | This is an optional capability. When specified, the portrait mode is enabled in the driver. |
+| **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** | This is an optional capability. When specified together with KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR , the shallow focus is enabled in the driver. |
 
 > [!NOTE]
 > From a SET perspective, **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** needs to be added along with **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR** to take effect;  They can also be set along with **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK**.
@@ -78,8 +78,7 @@ The table below contains the descriptions and requirements for the [KSCAMERA_EXT
 | Size | This must be **sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE)**. |
 | Result | Unused, must be 0. |
 | Capability | Must be a bitwise OR of the supported **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION _*** flags defined above. |
-| Flags | This is a read/write field. This can be any one of the **KSCAMERA_EXTENDEDPROP_ BACKGROUNDSEGMENTATION_*** flags
-defined above. From a SET perspective, PORTRAITMODE and BLUR need to be exclusive, however they can be set along with MASK. |
+| Flags | This is a read/write field. This can be any one of the **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION _*** flags defined above except SHALLOWFOCUS (which needs to be set together with BLUR to take effect), or valid combinations of the bits. From a SET perspective, shallow focus mode will be enabled only when both SHALLOWFOCUS and BLUR are set at the same time, they can be set along with MASK.|
 
 ## Requirements
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
@@ -26,14 +26,14 @@ Examples of setting KSPROPERTY controls can be found in the [AVStream Camera Sam
 
 Starting in Windows 11, version 22H2, Portrait mode has been introduced to the existing background segmentation control as an optional capability.
 
- **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE** is a new flag added to the KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION control that is used to control the Bokeh (Portrait mode) on the driver. This is a version of Background blur ([**KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION**](/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)), where the emphasis is less on privacy and more on making the background of the user look like from a higher quality camera with depth of field effect. This visually will make the foreground subject stand out, similar to how portrait mode photography on many mobile phones has become popular.
+ **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** is a new flag added to the KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION control that is used to control the Bokeh (shallow focus mode) on the driver. This is a version of Background blur ([**KSPROPERTY_CAMERACONTROL_EXTENDED_BACKGROUNDSEGMENTATION**](/windows-hardware/drivers/stream/ksproperty-cameracontrol-extended-backgroundsegmentation)), where the emphasis is less on privacy and more on making the background of the user look like from a higher quality camera with depth of field effect. This visually will make the foreground subject stand out, similar to how portrait mode photography on many mobile phones has become popular.
 
 The following table shows example images of how this works:
 
 | Mode | Example image |
 |--|--|
-| **Portrait & Blur Off** | ![background segmentation portrait blur off.](images/backgroundsegmentation-portrait-blur-off.png) |
-| **Portrait On** | ![background segmentation portrait on.](images/backgroundsegmentation-portrait-on.png) |
+| **Shallow Focus & Blur Off** | ![background segmentation portrait blur off.](images/backgroundsegmentation-portrait-blur-off.png) |
+| **Shallow Focus On** | ![background segmentation portrait on.](images/backgroundsegmentation-portrait-on.png) |
 | **Blur On** | ![background segmentation blur on.](images/backgroundsegmentation-blur-on.png) |
 
 ## Usage summary table
@@ -48,7 +48,7 @@ The following flags can be placed in the **KSCAMERA_EXTENDEDPROP_HEADER.Flags** 
 #define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF          0x0000000000000000
 #define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR         0x0000000000000001
 #define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK         0x0000000000000002
-#define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE 0x0000000000000004
+#define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS 0x0000000000000004
 ```
 
 If the driver supports this control, it must support BACKGROUNDSEMENTATION_OFF and one or more of the other flags.
@@ -64,10 +64,10 @@ The following table describes the flag capabilities.
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF** | This is a mandatory capability. When specified, the background segmentation is disabled in the driver. This is the default value. |
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR** | This is an optional capability. When specified, background blur is enabled in the driver and applies to frame if possible. |
 | **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK** | This is an optional capability. When specified, background mask metadata production is enabled in the driver (if possible given the MediaType used as expressed via the set of KSPROPERTY_CAMERACONTROL_EXTENDED_ BACKGROUNDSEGMENTATION_CONFIGCAPS returned in the *Size* field of the KSCAMERA_EXTENDEDPROP_HEADER). Note that this can be supported not only for color cameras but also depth and IR cameras. |
-| **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE** | This is an optional capability. When specified, the portrait mode is enabled in the driver. |
+| **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** | This is an optional capability. When specified, the portrait mode is enabled in the driver. |
 
 > [!NOTE]
-> From a SET perspective, **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE** and **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR** need to be exclusive, however they can be set along with **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK**.
+> From a SET perspective, **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS** needs to be added along with **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_BLUR** to take effect;  They can also be set along with **KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK**.
 
 The table below contains the descriptions and requirements for the [KSCAMERA_EXTENDEDPROP_HEADER](/windows-hardware/drivers/ddi/content/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure fields when using the control.
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-backgroundsegmentation.md
@@ -42,7 +42,7 @@ The following table shows example images of how this works:
 |--|--|--|
 | Version 1 | Filter | Synchronous |
 
-The following flags can be placed in the **KSCAMERA_EXTENDEDPROP_HEADER.Flags** field to control portrait mode.
+The following flags can be placed in the **KSCAMERA_EXTENDEDPROP_HEADER.Flags** field to control shallow focus mode.
 
 ```cpp
 #define KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF          0x0000000000000000


### PR DESCRIPTION
renamed KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_PORTRAITMODE to KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_SHALLOWFOCUS as per the SDK.