### PR TITLE
Update ksproperty-cameracontrol-extended-eyegazecorrection.md and sample code to match new DDI spec

### DIFF
--- a/windows-driver-docs-pr/stream/background-segmentation-portrait-mode-eye-gaze-stare-mode-driver-sample.md
+++ b/windows-driver-docs-pr/stream/background-segmentation-portrait-mode-eye-gaze-stare-mode-driver-sample.md
@@ -179,8 +179,17 @@ HRESULT CSampleMft::EyeGazeCorrectionHandler(
             //   
             // Use the extended value to make changes to the property.. refer documentation   
             // PKSCAMERA_EXTENDEDPROP_VALUE extendedValue = (PKSCAMERA_EXTENDEDPROP_VALUE)(payload + sizeof(KSCAMERA_EXTENDEDPROP_HEADER));   
-                             //   
-            SetEyeGazeCorrectionMode(extendedHeader->Flags);   
+            //
+            if ( (extendedHeader->Flags == KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON) ||
+                 (extendedHeader->Flags == (KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON | KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STAREMODE)) ||
+                 (extendedHeader->Flags == KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF) )
+            {
+                SetEyeGazeCorrectionMode (extendedHeader->Flags);   
+            }
+            else
+            {
+                RETURN_HR(E_INVALIDARG);
+            } 
             *bytesReturned = sizeof(PKSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE);   
         }   
         else  
@@ -206,7 +215,7 @@ HRESULT CSampleMft::EyeGazeCorrectionHandler(
             //   
             // Use the extended value to make changes to the property.. refer documentation   
             // PKSCAMERA_EXTENDEDPROP_VALUE extendedValue = (PKSCAMERA_EXTENDEDPROP_VALUE)(payload +sizeof(KSCAMERA_EXTENDEDPROP_HEADER));   
-                             //   
+            //   
             extendedHeader->Capability = KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF |  
                                          KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON |   
                                          KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STAREMODE;   

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
@@ -69,7 +69,7 @@ The following table describes the flag capabilities.
 | **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE** | This is an optional capability. When specified together with KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON, the stare/teleprompter mode is enabled in the driver. |
 
 > [!NOTE]
-> From a SET perspective, the stare mode will be enabled only when both KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE and KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON are set at the same time. KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits.
+> From a SET perspective, the stare mode will be enabled only when both **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE** and **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON** are set at the same time. **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF** needs to be exclusive to the other two bits.
 
 The table below contains the descriptions and requirements for the [KSCAMERA_EXTENDEDPROP_HEADER](/windows-hardware/drivers/ddi/content/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure fields when using the control.
 
@@ -80,7 +80,7 @@ The table below contains the descriptions and requirements for the [KSCAMERA_EXT
 | Size | This must be **sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE)**. |
 | Result | Unused, must be 0. |
 | Capability | Must be a bitwise OR of the supported **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_*** flags defined above. |
-| Flags | This is a read/write field. This can be any one of the KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_* flags defined above except STARE(which needs to be set together with ON to take effect), or valid combinations of the bits. From a SET perspective, the stare mode will be enabled only when both EYEGAZECORRECTION_STARE and EYEGAZECORRECTION_ON are set at the same time. EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits. |
+| Flags | This is a read/write field. This can be any one of the KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_* flags defined above except STARE(which needs to be set together with ON to take effect), or valid combinations of the bits. From a SET perspective, the stare mode will be enabled only when both KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE and KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON are set at the same time. KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits. |
 
 ## Requirements
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
@@ -69,7 +69,7 @@ The following table describes the flag capabilities.
 | **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE** | This is an optional capability. When specified together with KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON, the stare/teleprompter mode is enabled in the driver. |
 
 > [!NOTE]
-> From a SET perspective, the stare mode will be enabled only when both EYEGAZECORRECTION_STARE and EYEGAZECORRECTION_ON are set at the same time. EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits.
+> From a SET perspective, the stare mode will be enabled only when both KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE and KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON are set at the same time. KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits.
 
 The table below contains the descriptions and requirements for the [KSCAMERA_EXTENDEDPROP_HEADER](/windows-hardware/drivers/ddi/content/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure fields when using the control.
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
@@ -66,10 +66,10 @@ The following table describes the flag capabilities.
 |--|--|
 | **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_OFF** | This is a mandatory capability. When specified, the eye gaze correction is disabled in the driver. |
 | **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON** | This is a mandatory capability. When specified, the eye gaze correction is enabled in the driver. |
-| **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE** | This is an optional capability. When specified, the stare/teleprompter mode is enabled in the driver. |
+| **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_STARE** | This is an optional capability. When specified together with KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_ON, the stare/teleprompter mode is enabled in the driver. |
 
 > [!NOTE]
-> From a SET perspective, only one of the bits can be enabled at a time.
+> From a SET perspective, the stare mode will be enabled only when both EYEGAZECORRECTION_STARE and EYEGAZECORRECTION_ON are set at the same time. EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits.
 
 The table below contains the descriptions and requirements for the [KSCAMERA_EXTENDEDPROP_HEADER](/windows-hardware/drivers/ddi/content/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure fields when using the control.
 
@@ -80,7 +80,7 @@ The table below contains the descriptions and requirements for the [KSCAMERA_EXT
 | Size | This must be **sizeof(KSCAMERA_EXTENDEDPROP_HEADER) + sizeof(KSCAMERA_EXTENDEDPROP_VALUE)**. |
 | Result | Unused, must be 0. |
 | Capability | Must be a bitwise OR of the supported **KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_*** flags defined above. |
-| Flags | This is a read/write field. This can be any one of the KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_* flags defined above. For SET, only one of the bits can be enabled at a time. |
+| Flags | This is a read/write field. This can be any one of the KSCAMERA_EXTENDEDPROP_EYEGAZECORRECTION_* flags defined above except STARE(which needs to be set together with ON to take effect), or valid combinations of the bits. From a SET perspective, the stare mode will be enabled only when both EYEGAZECORRECTION_STARE and EYEGAZECORRECTION_ON are set at the same time. EYEGAZECORRECTION_OFF needs to be exclusive to the other two bits. |
 
 ## Requirements
 

--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-eyegazecorrection.md
@@ -22,7 +22,7 @@ This property ID controls an in-stream correction that a driver can perform to e
 
 Examples of setting KSPROPERTY controls can be found in the [AVStream Camera Sample Driver](https://github.com/microsoft/Windows-driver-samples/tree/master/avstream/avscamera) on GitHub.
 
-## Stare mode update to KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION control
+## Update to KSPROPERTY_CAMERACONTROL_EXTENDED_EYEGAZECORRECTION control
 
 Starting in Windows 11, version 22H2, Stare mode has been introduced to existing eye gaze correction control as an optional capability.
 


### PR DESCRIPTION
Modified statements about bit logic that STARE needs to be set together with ON to make effect, and updated sample code, to match new DDI spec.