### PR TITLE
Remove mention of some SetupDi*Ex methods from docs

### DIFF
--- a/windows-driver-docs-pr/install/accessing-the-friendly-name-and-class-name-of-a-device-setup-class.md
+++ b/windows-driver-docs-pr/install/accessing-the-friendly-name-and-class-name-of-a-device-setup-class.md
@@ -11,7 +11,7 @@ In Windows Vista and later versions of Windows, the [unified device property mod
 
 Windows Server 2003, Windows XP, and Windows 2000 also support these device setup class properties. However, these earlier versions of Windows do not support the property keys of the unified device property model. Instead, these versions of Windows use the following mechanisms to retrieve the corresponding property information:
 
--   Call [**SetupDiGetClassDescriptionEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptionexa) to retrieve the friendly name of a device setup class.
+-   Call [**SetupDiGetClassDescription**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptionw) to retrieve the friendly name of a device setup class.
 
 -   Call [**SetupDiClassNameFromGuid**](/windows/win32/api/setupapi/nf-setupapi-setupdiclassnamefromguida) to retrieve the class name of a device setup class.
 

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-characteristics.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-characteristics.md
@@ -79,6 +79,3 @@ Windows Server 2003 and Windows XP support this property, but do not support the
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-classcoinstallers.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-classcoinstallers.md
@@ -80,11 +80,7 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiSetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyw)
-
-[**SetupDiSetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyexw)
 
  
 

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-classinstaller.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-classinstaller.md
@@ -83,6 +83,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-classname.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-classname.md
@@ -72,8 +72,6 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiClassNameFromGuid**](/windows/win32/api/setupapi/nf-setupapi-setupdiclassnamefromguida)
 
  

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-defaultservice.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-defaultservice.md
@@ -77,6 +77,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32.Services Section**](./inf-classinstall32-services-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-devtype.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-devtype.md
@@ -81,6 +81,3 @@ Windows Server 2003 and Windows XP support this property, but do not support the
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-exclusive.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-exclusive.md
@@ -77,6 +77,3 @@ Windows Server 2003 and Windows XP support this property, but do not support the
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-icon.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-icon.md
@@ -76,8 +76,6 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiDrawMiniIcon**](/windows/win32/api/setupapi/nf-setupapi-setupdidrawminiicon)
 
 [**SetupDiLoadClassIcon**](/windows/win32/api/setupapi/nf-setupapi-setupdiloadclassicon)

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-iconpath.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-iconpath.md
@@ -74,8 +74,6 @@ Windows Server 2003, Windows XP, and Windows 2000 do not support this property. 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiLoadClassIcon**](/windows/win32/api/setupapi/nf-setupapi-setupdiloadclassicon)
 
  

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-lowerfilters.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-lowerfilters.md
@@ -84,7 +84,4 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
-[**SetupDiOpenClassRegKeyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdiopenclassregkeyexa)
-
+[**SetupDiOpenClassRegKey**](/windows/win32/api/setupapi/nf-setupapi-setupdiopenclassregkey)

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-name.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-name.md
@@ -74,9 +74,4 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
-[**SetupDiGetClassDescriptionEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptionexa)
-
- 
-
+[**SetupDiGetClassDescription**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptionw)

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-nodisplayclass.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-nodisplayclass.md
@@ -79,6 +79,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-noinstallclass.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-noinstallclass.md
@@ -79,6 +79,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-nouseclass.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-nouseclass.md
@@ -79,6 +79,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-proppageprovider.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-proppageprovider.md
@@ -83,6 +83,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-security.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-security.md
@@ -74,9 +74,4 @@ Windows Server 2003 and Windows XP support this property, but do not support the
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiSetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyw)
-
-[**SetupDiSetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-securitysds.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-securitysds.md
@@ -74,9 +74,4 @@ Windows Server 2003 and Windows XP support this property, but do not support the
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiSetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyw)
-
-[**SetupDiSetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdisetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-silentinstall.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-silentinstall.md
@@ -79,6 +79,3 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 [**INF ClassInstall32 Section**](./inf-classinstall32-section.md)
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
-
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-

--- a/windows-driver-docs-pr/install/devpkey-deviceclass-upperfilters.md
+++ b/windows-driver-docs-pr/install/devpkey-deviceclass-upperfilters.md
@@ -84,7 +84,5 @@ Windows Server 2003, Windows XP, and Windows 2000 support this property, but do 
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiOpenClassRegKeyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdiopenclassregkeyexa)
 

--- a/windows-driver-docs-pr/install/devpkey-name--device-setup-class-.md
+++ b/windows-driver-docs-pr/install/devpkey-name--device-setup-class-.md
@@ -83,8 +83,6 @@ Windows Server 2003, Windows XP, and Windows 2000 do not directly support a corr
 
 [**SetupDiGetClassProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyw)
 
-[**SetupDiGetClassPropertyEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclasspropertyexw)
-
 [**SetupDiGetClassDescription**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptiona)
 
 [**SetupDiClassNameFromGuid**](/windows/win32/api/setupapi/nf-setupapi-setupdiclassnamefromguida)

--- a/windows-driver-docs-pr/install/enumerating-installed-device-setup-classes.md
+++ b/windows-driver-docs-pr/install/enumerating-installed-device-setup-classes.md
@@ -16,9 +16,9 @@ To discover the [device setup classes](./overview-of-device-setup-classes.md) th
 
 To safely discover the installed device setup classes, and to query and modify the properties of a setup class, follow these steps:
 
-1.  Use [**SetupDiBuildClassInfoList**](/windows/win32/api/setupapi/nf-setupapi-setupdibuildclassinfolist) or [**SetupDiBuildClassInfoListEx**](/windows/win32/api/setupapi/nf-setupapi-setupdibuildclassinfolistexa) to retrieve the set of device setup classes that are currently installed on the system.
+1.  Use [**SetupDiBuildClassInfoList**](/windows/win32/api/setupapi/nf-setupapi-setupdibuildclassinfolist) to retrieve the set of device setup classes that are currently installed on the system.
 
-2.  Use [**SetupDiGetClassDescription**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptiona) or [**SetupDiGetClassDescriptionEx**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptionexa) to retrieve the description of an installed setup class.
+2.  Use [**SetupDiGetClassDescription**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdescriptiona) to retrieve the description of an installed setup class.
 
 3.  Use [**SetupDiGetClassRegistryProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetclassregistrypropertya) to query the setup class properties and [**SetupDiSetDeviceRegistryProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdisetdeviceregistrypropertya) to set the setup class properties.
 

--- a/windows-driver-docs-pr/install/inf-classinstall32-section.md
+++ b/windows-driver-docs-pr/install/inf-classinstall32-section.md
@@ -206,7 +206,7 @@ HKR,,Icon,,"101"
 
 [**RenFiles**](inf-renfiles-directive.md)
 
-[**SetupDiBuildClassInfoListEx**](/windows/win32/api/setupapi/nf-setupapi-setupdibuildclassinfolistexa)
+[**SetupDiBuildClassInfoList**](/windows/win32/api/setupapi/nf-setupapi-setupdibuildclassinfolist)
 
 [**UpdateIniFields**](inf-updateinifields-directive.md)
 


### PR DESCRIPTION
Functionality to access remote machines has been removed in Windows 8 and Windows Server 2012 and later operating systems thus you cannot access remote machines when running on these versions of Windows.

Remove mention of some SetupDi*Ex methods from docs:

- SetupDiGetClassPropertyEx
- SetupDiSetClassPropertyEx
- SetupDiBuildClassInfoListEx
- SetupDiGetClassDescriptionEx
- SetupDiOpenClassRegKeyEx
- SetupDiClassGuidsFromNameEx
- SetupDiClassNameFromGuidEx
- SetupDiInstallClassEx