### PR TITLE
Update code-signing-cert-manage.md

### DIFF
--- a/windows-driver-docs-pr/dashboard/code-signing-cert-manage.md
+++ b/windows-driver-docs-pr/dashboard/code-signing-cert-manage.md
@@ -25,10 +25,13 @@ To get a new code signing certificate:
 
 1. Go to the page of one the following certificate authorities and follow their directions for purchase:
 
-    * [DigiCert code signing certificate](https://www.digicert.com/order/order-1.php)
-    * [Entrust code signing certificate](https://www.entrustdatacard.com/products/digital-signing-certificates/code-signing-certificates)
-    * [GlobalSign code signing certificate](https://go.microsoft.com/fwlink/p/?LinkId=620888)
-    * [SSL.com code signing certificate](https://www.ssl.com/certificates/ev-code-signing/)
+    * [Certum EV code signing certificate](https://shop.certum.eu/data-safety/code-signing-certificates/certum-ev-code-sigining.html)
+    * [DigiCert EV code signing certificate](https://www.digicert.com/order/order-1.php)
+    * [Entrust EV code signing certificate](https://www.entrustdatacard.com/products/digital-signing-certificates/code-signing-certificates)
+    * [GlobalSign EV code signing certificate](https://go.microsoft.com/fwlink/p/?LinkId=620888)
+    * [IdenTrust EV code signing certificate](https://www.identrust.com/certificates/trustid-ev-code-signing)
+    * [Sectigo (formerly Comodo) EV code signing certificate](https://sectigo.com/ssl-certificates-tls/code-signing)
+    * [SSL.com EV code signing certificate](https://www.ssl.com/certificates/ev-code-signing/)
 
 1. Once the certificate authority has verified your contact information and your certificate purchase is approved, follow their directions to retrieve the certificate.
 


### PR DESCRIPTION
Reinstated links to CAs that were removed without reason: Certum, IdenTrust and Sectigo.