### PR TITLE
Updates to clarify privacy shutter/switch requirements

### DIFF
--- a/windows-driver-docs-pr/stream/camera-privacy-controls.md
+++ b/windows-driver-docs-pr/stream/camera-privacy-controls.md
@@ -1,10 +1,10 @@
 ---
-title: Camera privacy controls
+title: Camera privacy shutters and kill switches
 description: Provides device design guidance for privacy shutters and kill switches, considerations for shutter state sensing, and how shutters are expected to interact with existing HLK requirements for indicator LEDs.
 ms.date: 03/18/2022
 ---
 
-# Camera privacy controls
+# Camera privacy shutters and kill switches
 
 This topic provides device design guidance for privacy shutters or kill switches, considerations for shutter state sensing, and how shutters are expected to interact with existing HLK requirements for indicator LEDs.
 
@@ -224,7 +224,7 @@ HLK requires that the indicator LED be ON when the ISP is capturing sensor data.
 
 The state of the kill switch should be reported through CT_PRIVACY_CONTROL (if originating from a UVC device), or KSPROPERTY_CAMERACONTROL_PRIVACY (if originating from an AVStream or DMFT driver). The state of the Camera Kill Switch should be reported whenever the ISP is out of D3.
 
-See [Privacy shutter notification](privacy-shutter-notification.md) for more details.
+See [Privacy shutter/switch notification](privacy-shutter-notification.md) for more details.
 
 ![kill switch state reporting](images/camera-privacy-controls-10.png)
 

--- a/windows-driver-docs-pr/stream/index.md
+++ b/windows-driver-docs-pr/stream/index.md
@@ -25,9 +25,9 @@ Use the guidance in this section to design and implement drivers for devices tha
 
 ## New and updated content for Windows 11
 
-[Camera privacy controls](camera-privacy-controls.md)
+[Camera privacy shutters and kill switches](camera-privacy-controls.md)
 
-[Privacy shutter notification](privacy-shutter-notification.md)
+[Privacy shutter/switch notification](privacy-shutter-notification.md)
 
 [Digital Window overview](digital-window-overview.md)
 

--- a/windows-driver-docs-pr/stream/toc.yml
+++ b/windows-driver-docs-pr/stream/toc.yml
@@ -1,14 +1,11 @@
 - name: "Streaming media devices design guide"
   href: index.md
-- name: "Camera privacy controls"
+- name: "Camera privacy controls (shutters and kill switches)"
 # Auto-expanded node
   items: 
-  - name: "Camera privacy controls"
+  - name: "Camera privacy shutters and kill switches"
     href: camera-privacy-controls.md
-- name: "Privacy shutter notification"
-# Auto-expanded node
-  items: 
-  - name: "Privacy shutter notification"
+  - name: "Privacy shutter/switch notification"
     href: privacy-shutter-notification.md
 - name: "Background segmentation portrait mode and eye gaze stare mode driver sample"
 # Auto-expanded node


### PR DESCRIPTION
- Grouped HW design details doc and driver implementation details doc together via table of contents
- Renamed the two docs to be more clear
- Updated "should"/"must" language to match HLK requirements
- Clarified notification API applies to shutters and kill switches
- Clarified that shutters are not required, but notification is required IF a shutter/switch is used on a device