### PR TITLE
Update Ksproperty-cameracontrol-extended-cameraangleoffset.md

### DIFF
--- a/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-cameraangleoffset.md
+++ b/windows-driver-docs-pr/stream/ksproperty-cameracontrol-extended-cameraangleoffset.md
@@ -49,9 +49,9 @@ The camera angle offset property provides read-only information about the pitch 
 
  
 
-The property value (operation data) contains a [**KSCAMERA\_EXTENDEDPROP\_HEADER**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure and a [**KSCAMERA\_EXTENDEDPROP\_FIELDOFVIEW**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_fieldofview) structure.
+The property value (operation data) contains a [**KSCAMERA\_EXTENDEDPROP\_HEADER**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) structure and a [**KSCAMERA\_EXTENDEDPROP\_CAMERAOFFSET**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_cameraoffset) structure.
 
-The total property data size is **sizeof**(KSCAMERA\_EXTENDEDPROP\_HEADER) + **sizeof**(KSCAMERA\_EXTENDEDPROP\_FIELDOFVIEW). The **Size** member of [**KSCAMERA\_EXTENDEDPROP\_HEADER**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) is set to this total property data size.
+The total property data size is **sizeof**(KSCAMERA\_EXTENDEDPROP\_HEADER) + **sizeof**(KSCAMERA\_EXTENDEDPROP\_CAMERAOFFSET). The **Size** member of [**KSCAMERA\_EXTENDEDPROP\_HEADER**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) is set to this total property data size.
 
 The **Capability** and **Flags** members of [**KSCAMERA\_EXTENDEDPROP\_HEADER**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-tagkscamera_extendedprop_header) are not used for this property.
 


### PR DESCRIPTION
The query result of KSPROPERTY_CAMERACONTROL_EXTENDED_CAMERAANGLEOFFSET is supposed to be KSCAMERA_EXTENDEDPROP_HEADER + KSCAMERA_EXTENDEDPROP_CAMERAOFFSET. 
However, the description on the page was KSCAMERA_EXTENDEDPROP_HEADER + KSCAMERA_EXTENDEDPROP_FIELDOFVIEW.

Fixed the error