### PR TITLE
Fix code text

### DIFF
--- a/windows-driver-docs-pr/debugger/using-umdh-to-find-a-user-mode-memory-leak.md
+++ b/windows-driver-docs-pr/debugger/using-umdh-to-find-a-user-mode-memory-leak.md
@@ -63,7 +63,7 @@ After making these preparations, you can use UMDH to capture information about t
 
     ```console
     umdh -p:124 -f:log1.txt 
-    ```dbgcmd
+    ```
 
 3.  Use Notepad or another program to open the log file. This file contains the call stack for each heap allocation, the number of allocations made through that call stack, and the number of bytes consumed through that call stack.
 


### PR DESCRIPTION
[Detecting Increases in Heap Allocations with UMDH](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/using-umdh-to-find-a-user-mode-memory-leak?source=docs#detecting-increases-in-heap-allocations-with-umdh) has

    ```console
    umdh -p:124 -f:log1.txt 
    ```dbgcmd

instead of

    ```console
    umdh -p:124 -f:log1.txt 
    ```