### PR TITLE
Move playback IOCTL to separate subheading

### DIFF
--- a/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
+++ b/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
@@ -34,7 +34,7 @@ Class drivers for CD-ROM devices handle additional public I/O control codes, alo
 |[IOCTL_CDROM_SET_SPEED](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_set_speed)|Sets the spindle speed of the CD-ROM drive.|
 
 
-# Media playback control
+## Media playback control
 Beginning with Windows Vista, CDROM class drivers do not use these IOCTL. Prior to Windows Vista, these IOCTL was used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
 
 Client applications should use the Media Control Interface (MCI) API rather than issuing these IOCTL.

--- a/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
+++ b/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
@@ -21,22 +21,32 @@ Class drivers for CD-ROM devices handle additional public I/O control codes, alo
 |[IOCTL_CDROM_EXCLUSIVE_ACCESS](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_exclusive_access)|Instructs the CD-ROM class driver to export the access state of a CD-ROM device, lock a CD-ROM device for exclusive access, and unlock a CD-ROM device for exclusive access.|
 |[IOCTL_CDROM_FIND_NEW_DEVICES](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_find_new_devices)|This IOCTL is replaced by [IOCTL_STORAGE_FIND_NEW_DEVICES](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_find_new_devices). The only difference between the two IOCTLs is the base value.|
 |[IOCTL_CDROM_GET_CONFIGURATION](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_configuration)|Requests feature and profile information from a CD-ROM device.|
-|[IOCTL_CDROM_GET_CONTROL](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_control)|This IOCTL request is obsolete. Do not use.|
 |[IOCTL_CDROM_GET_DRIVE_GEOMETRY](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_drive_geometry)|Returns information about the CD-ROM's geometry (media type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector).|
 |[IOCTL_CDROM_GET_DRIVE_GEOMETRY_EX](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_drive_geometry_ex)|Returns information about a CD-ROM's geometry (media type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector).|
 |[IOCTL_CDROM_GET_INQUIRY_DATA](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_inquiry_data)|Returns the SCSI inquiry data for the CD-ROM device. This IOCTL can be used when a device has been exclusively locked with [IOCTL_CDROM_EXCLUSIVE_ACCESS](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_exclusive_access).|
 |[IOCTL_CDROM_GET_LAST_SESSION](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_last_session)|Queries the device for the first complete session number, the last complete session number, and the last complete session starting address.|
 |[IOCTL_CDROM_GET_PERFORMANCE](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_performance)|Retrieves the supported speeds from the device. The **IOCTL_CDROM_GET_PERFORMANCE** I/O control request is a wrapper over the MMC command, GET PERFORMANCE.|
-|[IOCTL_CDROM_GET_VOLUME](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_volume)|Obsolete. Determines the current volume for each of its device's audio ports.|
 |[IOCTL_CDROM_LOAD_MEDIA](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_load_media)|Draws a protruding CDROM tray back into the drive.|
-|[IOCTL_CDROM_PAUSE_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_pause_audio)|Obsolete. Suspends audio play.|
-|[IOCTL_CDROM_PLAY_AUDIO_MSF](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_play_audio_msf)|Obsolete. Plays the specified range of the media.|
-|[IOCTL_CDROM_READ_Q_CHANNEL](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_q_channel)|Obsolete. Returns the current position, media catalog, or ISRC track data.|
+|[IOCTL_CDROM_READ_Q_CHANNEL](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_q_channel)|Returns the current position (obsolete), media catalog, or ISRC track data.|
 |[IOCTL_CDROM_READ_TOC](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_toc)|Obsolete. Returns the table of contents of the media.|
 |[IOCTL_CDROM_READ_TOC_EX](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_toc_ex)|Queries the target device for the table of contents (TOC), the program memory area (PMA), and the absolute time in pregroove (ATIP).|
-|[IOCTL_CDROM_RESUME_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_resume_audio)|Obsolete. Resumes a suspended audio operation.|
-|[IOCTL_CDROM_SEEK_AUDIO_MSF](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_seek_audio_msf)|Obsolete. Moves the heads to the specified MSF on the media.|
 |[IOCTL_CDROM_SEND_OPC_INFORMATION](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_send_opc_information)|Used in file systems and other implementations that want to perform the Optimum Power Calibration (OPC) procedure in advance, so that the first streaming write does not have to wait for the procedure to finish.|
 |[IOCTL_CDROM_SET_SPEED](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_set_speed)|Sets the spindle speed of the CD-ROM drive.|
-|[IOCTL_CDROM_SET_VOLUME](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_set_volume)|Obsolete. Resets the volume for its device's audio ports.|
-|[IOCTL_CDROM_STOP_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_stop_audio)|Obsolete. Ends audio play.|
+
+
+# Media playback control
+Beginning with Windows Vista, CDROM class drivers do not use these IOCTL. Prior to Windows Vista, these IOCTL was used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
+
+Client applications should use the Media Control Interface (MCI) API rather than issuing these IOCTL.
+
+|I/O control code|Description|
+|----|----|
+|[IOCTL_CDROM_GET_CONTROL](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_control)|Determines the current audio playback mode.|
+|[IOCTL_CDROM_GET_VOLUME](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_get_volume)|Determines the current volume for each of its device's audio ports.|
+|[IOCTL_CDROM_PAUSE_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_pause_audio)|Suspends audio play.|
+|[IOCTL_CDROM_PLAY_AUDIO_MSF](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_play_audio_msf)|Plays the specified range of the media.|
+|[IOCTL_CDROM_READ_Q_CHANNEL](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_q_channel)|Returns the current position (obsolete), media catalog, or ISRC track data.|
+|[IOCTL_CDROM_RESUME_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_resume_audio)|Resumes a suspended audio operation.|
+|[IOCTL_CDROM_SEEK_AUDIO_MSF](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_seek_audio_msf)|Moves the heads to the specified MSF on the media.|
+|[IOCTL_CDROM_SET_VOLUME](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_set_volume)|Resets the volume for its device's audio ports.|
+|[IOCTL_CDROM_STOP_AUDIO](/windows-hardware/drivers/ddi/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_stop_audio)|Ends audio play.|

--- a/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
+++ b/windows-driver-docs-pr/storage/cd-rom-io-control-codes.md
@@ -35,9 +35,9 @@ Class drivers for CD-ROM devices handle additional public I/O control codes, alo
 
 
 ## Media playback control
-Beginning with Windows Vista, CDROM class drivers do not use these IOCTL. Prior to Windows Vista, these IOCTL was used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
+Beginning with Windows Vista, CDROM class drivers do not use these IOCTLs. Prior to Windows Vista, these IOCTLs were used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
 
-Client applications should use the Media Control Interface (MCI) API rather than issuing these IOCTL.
+Client applications should use the [Media Control Interface (MCI)](/windows/win32/multimedia/media-control-interface--mci) API rather than issuing these IOCTLs.
 
 |I/O control code|Description|
 |----|----|


### PR DESCRIPTION
This makes it easier to focus on the still useful IOCTL commands.