### PR TITLE
Remove references to UMDF 1.x

### DIFF
--- a/windows-driver-docs-pr/gettingstarted/index.md
+++ b/windows-driver-docs-pr/gettingstarted/index.md
@@ -12,7 +12,7 @@ ms.topic: article
 
 Start here to learn fundamental concepts about drivers.
 
-You should already be familiar with the [C programming language](/cpp/c-language/c-language-reference), and you should understand the ideas of function pointers, callback functions, and event handlers. If you are going to write a driver based on User-Mode Driver Framework 1.x, you should be familiar with [C++ and COM](/windows/win32/learnwin32/learn-to-program-for-windows).
+You should already be familiar with the [C programming language](/cpp/c-language/c-language-reference), and you should understand the ideas of function pointers, callback functions, and event handlers.
 
 ## In this section
 


### PR DESCRIPTION
Remove references to UMDF 1.x . UMDF v2 is recommended and V1 is no longer the recommended model