### PR TITLE
Modify the variable name of the example code in control-guid.md

### DIFF
--- a/windows-driver-docs-pr/devtest/control-guid.md
+++ b/windows-driver-docs-pr/devtest/control-guid.md
@@ -23,7 +23,7 @@ The control GUID appears in the [WPP\_CONTROL\_GUIDS](/previous-versions/windows
         WPP_DEFINE_BIT(NameOfTraceFlag2)  \
         .............................   \
         .............................   \
-        WPP_DEFINE_BIT(NameOfTraceFlag31) )
+        WPP_DEFINE_BIT(NameOfTraceFlag32) )
 ```
 
 [Tracepdb](tracepdb.md) creates a [trace (MOF) file](trace-managed-object-format--mof--file.md) that contains the control GUID and the trace levels of each trace provider that is represented in the PDB file. The name of the MOF file is the module name of the trace provider. Tracepdb can also produce a TMC file if you use the **-c** option.


### PR DESCRIPTION
- The NameOfTraceFlag32 variable name can better describe the range of bit 0 to bit 31. 

- Reference link https://github.com/microsoft/Windows-driver-samples/blob/45b95c2ad0f3100525deb6c0c35dcbc37e7025b5/general/PLX9x5x/sys/trace.h#L60
- It may seem trivial, but it makes the maximum number of variables 32 easier to understand.