### PR TITLE
cpp to console hint fix

### DIFF
--- a/windows-driver-docs-pr/install/release-signing-a-driver-package-s-catalog-file.md
+++ b/windows-driver-docs-pr/install/release-signing-a-driver-package-s-catalog-file.md
@@ -24,7 +24,7 @@ The following command line shows how to run SignTool to do the following:
 
 To release-sign the *tstamd64.cat* catalog file, run the following command line:
 
-```cpp
+```console
 Signtool sign /v /fd sha256 /ac MSCV-VSClass3.cer /s MyPersonalStore /n contoso.com /t http://timestamp.digicert.com tstamd64.cat
 ```
 


### PR DESCRIPTION
at the docs website, it shows that the signtool is supossed to be part of c++ which is not  true. The fix is to show the appropriate "console" to the code box.