### PR TITLE
Moving provisioning VM note to top

### DIFF
--- a/windows-driver-docs-pr/gettingstarted/provision-a-target-computer-wdk-8-1.md
+++ b/windows-driver-docs-pr/gettingstarted/provision-a-target-computer-wdk-8-1.md
@@ -8,6 +8,9 @@ ms.date: 10/29/2021
 
 *Provisioning a target or test computer* is the process of configuring a computer for automatic driver deployment, testing, and debugging. To provision a computer, use Microsoft Visual Studio.
 
+> [!NOTE]
+> Provisioning virtual machines through the WDK's automatic provisioning process is not supported. However, you can test drivers on a VM by setting up the target VM manually as described in the [step by step echo lab](../debugger/debug-universal-drivers---step-by-step-lab--echo-kernel-mode-.md).
+
 A testing and debugging environment has two computers: the *host computer* and the *target computer*. The target computer is also called the *test computer*. You develop and build your driver in Visual Studio on the host computer. The debugger runs on the host computer and is available in the Visual Studio user interface. When you test and debug a driver, the driver runs on the target computer.
 
 The host and target computers must be able to ping each other by name. This might be easier if both computers are joined to the same workgroup or the same network domain. If your computers are in a workgroup, we recommend that you connect the computers with a router rather than a hub or switch.
@@ -67,9 +70,6 @@ Now you're ready to provision the target computer from the host computer in Visu
     For more information about setting up debugging over various types of connections, see [Setting Up KDNET Network Kernel Debugging Manually](../debugger/setting-up-a-network-debugging-connection.md) and the related  documentation for the [Debugging Tools for Windows](../debugger/index.md).
 
 6. The provisioning process takes several minutes and might automatically reboot the target computer once or twice. When provisioning is complete, select **Finish**.
-
-> [!NOTE]
-> Provisioning virtual machines through the WDK's automatic provisioning process is not supported. However, you can test drivers on a VM by setting up the target VM manually as described in the [step by step echo lab](../debugger/debug-universal-drivers---step-by-step-lab--echo-kernel-mode-.md).
 
 ## See Also
 


### PR DESCRIPTION
Moving the note about provisioning VMs from bottom to the top of the article to avoid wasting time to developers who want to provision VMs