### PR TITLE
SerCx: Add documentation for device interface creation

### DIFF
--- a/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
+++ b/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
@@ -1,7 +1,7 @@
 ---
 title: Accessing a Device on a SerCx2-Managed Serial Port
 description: SerCx2 and a serial controller driver jointly manage a serial port to which a peripheral device is permanently connected.
-ms.date: 04/20/2017
+ms.date: 01/20/2023
 ---
 
 # Accessing a Device on a SerCx2-Managed Serial Port
@@ -13,11 +13,11 @@ SerCx2 and a serial controller driver jointly manage a serial port to which a pe
 
 - [Peripheral Drivers for Devices on SerCx2-Managed Serial Ports](peripheral-drivers-for-devices-on-sercx2-managed-serial-ports.md)  
 
-    Typically, a serial port managed by SerCx2 is permanently connected to a peripheral device. This device is controlled by a peripheral driver that sends I/O requests to the serial port. These requests transfer data to and from the device, and configure the state of the serial port. I/O requests sent by the peripheral driver are jointly handled by SerCx2 and an associated serial controller driver. |
+    Typically, a serial port managed by SerCx2 is permanently connected to a peripheral device. This device is controlled by a peripheral driver that sends I/O requests to the serial port. These requests transfer data to and from the device, and configure the state of the serial port. I/O requests sent by the peripheral driver are jointly handled by SerCx2 and an associated serial controller driver.
 
 - [Opening a SerCx2-Managed Serial Port](opening-a-sercx2-managed-serial-port.md)
 
-    If your peripheral driver controls a device on a serial port that is jointly managed by SerCx2 and a serial controller driver, your driver can open a logical connection to this port and then send I/O requests to the device through the port. |
+    If your peripheral driver controls a device on a serial port that is jointly managed by SerCx2 and a serial controller driver, your driver can open a logical connection to this port and then send I/O requests to the device through the port.
 
 - [SerCx2 Handling of Read and Write Requests](sercx2-handling-of-read-and-write-requests.md)
 
@@ -25,4 +25,8 @@ SerCx2 and a serial controller driver jointly manage a serial port to which a pe
 
 - [Reading Data from a SerCx2-Managed Serial Port](reading-data-from-a-sercx2-managed-serial-port.md)
 
-    A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to the serial port.</p></td>
+    A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to the serial port.
+
+- [Device Interface publication for a SerCx or SerCx2-managed Serial Port](device-interface-publication-sercx.md)
+
+    Starting with Windows 10 version 1903 and later, system manufacturers or integrators may opt-in via ACPI to have SerCx/SerCx2 expose serial ports to applications and services as a device interface.

--- a/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
+++ b/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
@@ -21,11 +21,11 @@ SerCx2 and a serial controller driver jointly manage a serial port to which a pe
 
 - [SerCx2 Handling of Read and Write Requests](sercx2-handling-of-read-and-write-requests.md)
 
-    A peripheral driver sends write ([**IRP_MJ_WRITE**](/previous-versions/ff546904(v=vs.85))) and read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to a port on a serial controller to transfer data to and from a peripheral device that is connected to the port. The way in which SerCx2 handles these requests is well-defined, even when the requests time out or are canceled.
+    A peripheral driver sends write ([**IRP_MJ_WRITE**](/windows-hardware/drivers/kernel/irp-mj-write)) and read ([**IRP_MJ_READ**](/windows-hardware/drivers/kernel/irp-mj-read)) requests to a port on a serial controller to transfer data to and from a peripheral device that is connected to the port. The way in which SerCx2 handles these requests is well-defined, even when the requests time out or are canceled.
 
 - [Reading Data from a SerCx2-Managed Serial Port](reading-data-from-a-sercx2-managed-serial-port.md)
 
-    A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to the serial port.
+    A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read ([**IRP_MJ_READ**](/windows-hardware/drivers/kernel/irp-mj-read)) requests to the serial port.
 
 - [Device Interface publication for a SerCx or SerCx2-managed Serial Port](device-interface-publication-sercx.md)
 

--- a/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
+++ b/windows-driver-docs-pr/serports/accessing-a-device-on-a-sercx2-managed-serial-port.md
@@ -11,37 +11,18 @@ SerCx2 and a serial controller driver jointly manage a serial port to which a pe
 
 ## In this section
 
+- [Peripheral Drivers for Devices on SerCx2-Managed Serial Ports](peripheral-drivers-for-devices-on-sercx2-managed-serial-ports.md)  
 
-<table>
-<colgroup>
-<col width="50%" />
-<col width="50%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Topic</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p><a href="peripheral-drivers-for-devices-on-sercx2-managed-serial-ports.md" data-raw-source="[Peripheral Drivers for Devices on SerCx2-Managed Serial Ports](peripheral-drivers-for-devices-on-sercx2-managed-serial-ports.md)">Peripheral Drivers for Devices on SerCx2-Managed Serial Ports</a></p></td>
-<td><p>Typically, a serial port managed by SerCx2 is permanently connected to a peripheral device. This device is controlled by a peripheral driver that sends I/O requests to the serial port. These requests transfer data to and from the device, and configure the state of the serial port. I/O requests sent by the peripheral driver are jointly handled by SerCx2 and an associated serial controller driver.</p></td>
-</tr>
-<tr class="even">
-<td><p><a href="opening-a-sercx2-managed-serial-port.md" data-raw-source="[Opening a SerCx2-Managed Serial Port](opening-a-sercx2-managed-serial-port.md)">Opening a SerCx2-Managed Serial Port</a></p></td>
-<td><p>If your peripheral driver controls a device on a serial port that is jointly managed by SerCx2 and a serial controller driver, your driver can open a logical connection to this port and then send I/O requests to the device through the port.</p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="sercx2-handling-of-read-and-write-requests.md" data-raw-source="[SerCx2 Handling of Read and Write Requests](sercx2-handling-of-read-and-write-requests.md)">SerCx2 Handling of Read and Write Requests</a></p></td>
-<td><p>A peripheral driver sends write (<a href="/previous-versions/ff546904(v=vs.85)" data-raw-source="[&lt;strong&gt;IRP_MJ_WRITE&lt;/strong&gt;](/previous-versions/ff546904(v=vs.85))"><strong>IRP_MJ_WRITE</strong></a>) and read (<a href="/previous-versions/ff546883(v=vs.85)" data-raw-source="[&lt;strong&gt;IRP_MJ_READ&lt;/strong&gt;](/previous-versions/ff546883(v=vs.85))"><strong>IRP_MJ_READ</strong></a>) requests to a port on a serial controller to transfer data to and from a peripheral device that is connected to the port. The way in which SerCx2 handles these requests is well-defined, even when the requests time out or are canceled.</p></td>
-</tr>
-<tr class="even">
-<td><p><a href="reading-data-from-a-sercx2-managed-serial-port.md" data-raw-source="[Reading Data from a SerCx2-Managed Serial Port](reading-data-from-a-sercx2-managed-serial-port.md)">Reading Data from a SerCx2-Managed Serial Port</a></p></td>
-<td><p>A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read (<a href="/previous-versions/ff546883(v=vs.85)" data-raw-source="[&lt;strong&gt;IRP_MJ_READ&lt;/strong&gt;](/previous-versions/ff546883(v=vs.85))"><strong>IRP_MJ_READ</strong></a>) requests to the serial port.</p></td>
-</tr>
-</tbody>
-</table>
+    Typically, a serial port managed by SerCx2 is permanently connected to a peripheral device. This device is controlled by a peripheral driver that sends I/O requests to the serial port. These requests transfer data to and from the device, and configure the state of the serial port. I/O requests sent by the peripheral driver are jointly handled by SerCx2 and an associated serial controller driver. |
 
- 
+- [Opening a SerCx2-Managed Serial Port](opening-a-sercx2-managed-serial-port.md)
 
+    If your peripheral driver controls a device on a serial port that is jointly managed by SerCx2 and a serial controller driver, your driver can open a logical connection to this port and then send I/O requests to the device through the port. |
+
+- [SerCx2 Handling of Read and Write Requests](sercx2-handling-of-read-and-write-requests.md)
+
+    A peripheral driver sends write ([**IRP_MJ_WRITE**](/previous-versions/ff546904(v=vs.85))) and read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to a port on a serial controller to transfer data to and from a peripheral device that is connected to the port. The way in which SerCx2 handles these requests is well-defined, even when the requests time out or are canceled.
+
+- [Reading Data from a SerCx2-Managed Serial Port](reading-data-from-a-sercx2-managed-serial-port.md)
+
+    A serial controller (or UART) typically includes a receive FIFO. This FIFO provides hardware-controlled buffering of data received from the peripheral device that is connected to the serial port. To read data from the receive FIFO, the peripheral driver for this device sends read ([**IRP_MJ_READ**](/previous-versions/ff546883(v=vs.85))) requests to the serial port.</p></td>

--- a/windows-driver-docs-pr/serports/device-interface-publication-sercx.md
+++ b/windows-driver-docs-pr/serports/device-interface-publication-sercx.md
@@ -1,0 +1,230 @@
+---
+title: Device Interface publication for a SerCx or SerCx2 managed Serial Port
+description: Learn how to publish a device interface for a SerCx or SerCx2 managed serial port.
+ms.date: 01/20/2023
+---
+
+# Device Interface publication for a SerCx or SerCx2 managed Serial Port
+
+Starting with Windows 10 version 1903 and later, SerCx and SerCx2 include support for publishing a `GUID_DEVINTERFACE_COMPORT` *device interface*. Applications and services on a system are able to use this device interface to interact with the serial port.
+
+A COM port number is not assigned for these devices, and no symbolic link is created - meaning that applications must use the described approach to open the serial port as a device interface, rather than a named COM port.
+
+## Opting In
+
+Below are the instructions to opt-in to device interface creation. Note that serial ports are **exclusive**, meaning if the serial port is accessible as a device interface, a connection resource in ACPI should **not** be provided to any other devices - e.g. no `UARTSerialBusV2` resource should be provided to any other devices on the system; the port should be made **exclusively** accessible via the device interface.
+
+### ACPI Configuration
+A system manufacturer or integrator may opt-in to this behavior by modifying the ACPI (ASL) definition of the **existing** SerCx/SerCx2 device to add a `_DSD` definition for key-value device properties with UUID `daffd814-6eba-4d8c-8a91-bc9bbf4aa301`. Inside this definition, the property `SerCx-FriendlyName` is defined with a system specific description of the serial port, for example, `UART0`, `UART1`, etc.
+
+Example device definition (excluding vendor specific information necessary to define the device):
+```
+    Device(URT0) {
+        Name(_HID, ...)
+        Name(_CID, ...)
+
+        Name(_DSD, Package() {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package() {
+                Package(2) {"SerCx-FriendlyName", "UART0"}
+            }
+        })
+    }
+```
+
+The specified UUID (`daffd814-6eba-4d8c-8a91-bc9bbf4aa301`) **must** be used, and the key `SerCx-FriendlyName` must be defined for SerCx/SerCx2 to create the device interface.
+
+### Registry Key
+For development purposes, the `SerCx-FriendlyName` may also be configured as a device property in the registry. In an extension INF, or manually, the key `SerCx-FriendlyName` can be added to the device and used by SerCx/SerCx2 to retrieve the friendly name for the device interface.
+
+## Device Interface
+If a `FriendlyName` is defined using the methods above, SerCx/SerCx2 will publish a `GUID_DEVINTERFACE_COMPORT` *device interface* for the controller. This device interface will set the `DEVPKEY_DeviceInterface_Serial_PortName` property to the specified friendly name, which may be used by applications to locate a specific controller/port.
+
+### Enabling unprivileged access
+By default, the controller/port will be accessible only to privileged users and applications. If access from unprivileged applications is required, the SerCx/SerCx2 client must override the default security descriptor after calling `SerCx2InitializeDeviceInit()` or `SerCxDeviceInitConfig()`.
+
+An example of how to enable unprivileged access on SerCx2 from within the SerCx2 client controller driver's `EvtDeviceAdd` is below.
+
+```cpp
+SampleControllerEvtDeviceAdd(
+    WDFDRIVER WdfDriver,
+    WDFDEVICE_INIT WdfDeviceInit
+)
+{
+    ...
+
+    NTSTATUS status = SerCx2InitializeDeviceInit(WdfDeviceInit);
+    if (!NT_SUCCESS(status)) {
+        ...
+    }
+
+    // Declare a security descriptor allowing access to all
+    DECLARE_CONST_UNICODE_STRING(
+        SDDL_DEVOBJ_SERCX_SYS_ALL_ADM_ALL_UMDF_ALL_USERS_RDWR,
+        L"D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;UD)(A;;GRGW;;;BU)");
+
+    // Assign it to the device, overwriting the default SerCx2 security descriptor
+    status = WdfDeviceInitAssignSDDLString(
+                WdfDeviceInit,
+                &SDDL_DEVOBJ_SERCX_SYS_ALL_ADM_ALL_UMDF_ALL_USERS_RDWR);
+
+    if (!NT_SUCCESS(status)) {
+        ...
+    }
+
+    ...
+}
+```
+
+### Behavior changes when using a Device Interface
+Opting in to this feature results in the following behavioral changes in SerCx/SerCx2 (as opposed to [accessing the SerCx/SerCx2 controller via a connection ID](opening-a-sercx2-managed-serial-port.md)):
+
+- No default configuration is applied to the port (speed, parity, etc). As there is no connection resource in ACPI to describe this, the port begins in an unitialized state. Software that interacts with the device interface is required to configure the port using the defined serial IOCTL interface. 
+
+- Calls from the SerCx/SerCx2 client driver to query or apply the default configuration will return a failure status. Additionally, `IOCTL_SERIAL_APPLY_DEFAULT_CONFIGURATION` requests to the device interface will be failed as there is no default configuration specified to apply.
+
+
+## Accessing the Serial Port Device Interface
+For UWP applications, the published interface may be accessed using the `Windows.Devices.SerialCommunication` namespace APIs like any other compliant serial port.
+
+For Win32 applications, the device interface is located and accessed using the following process:
+1. Application calls `CM_Get_Device_Interface_ListW` to get a list of all `GUID_DEVINTERFACE_COMPORT` class device interfaces on the system
+2. Application calls `CM_Get_Device_Interface_PropertyW` for each returned interface to query the `DEVPKEY_DeviceInterface_Serial_PortName` for each interface discovered
+3. When the desired port is found by name, application uses the symbolic link string returned in (1) to open a handle to the port via `CreateFile()`
+
+Sample code for this flow:
+```cpp
+DWORD ret;
+ULONG deviceInterfaceListBufferLength;
+
+//
+// Determine the size (in characters) of buffer required for to fetch a list of
+// all GUID_DEVINTERFACE_COMPORT device interfaces present on the system.
+//
+ret = CM_Get_Device_Interface_List_SizeW(
+        &deviceInterfaceListBufferLength,
+        &GUID_DEVINTERFACE_COMPORT,
+        NULL,
+        CM_GET_DEVICE_INTERFACE_LIST_PRESENT);
+if (ret != CR_SUCCESS) {
+    // Handle error
+    ...
+}
+
+//
+// Allocate buffer of the determined size.
+//
+PWCHAR deviceInterfaceListBuffer = malloc(deviceInterfaceListBufferLength * sizeof(WCHAR));
+if (deviceInterfaceListBuffer == NULL) {
+    // Handle error
+    ...
+}
+
+//
+// Fetch the list of all GUID_DEVINTERFACE_COMPORT device interfaces present
+// on the system.
+//
+ret = CM_Get_Device_Interface_ListW(
+        &GUID_DEVINTERFACE_COMPORT,
+        NULL,
+        deviceInterfaceListBuffer,
+        deviceInterfaceListBufferLength,
+        CM_GET_DEVICE_INTERFACE_LIST_PRESENT);
+if (ret != CR_SUCCESS) {
+    // Handle error
+    ...
+}
+
+//
+// Iterate through the list, examining one interface at a time
+//
+PWCHAR currentInterface = deviceInterfaceListBuffer;
+while (*currentInterface) {
+    //
+    // Fetch the DEVPKEY_DeviceInterface_Serial_PortName for this interface
+    //
+    CONFIGRET configRet;
+    DEVPROPTYPE devPropType;
+    PWCHAR devPropBuffer;
+    ULONG devPropSize = 0;
+
+    // First, get the size of buffer required
+    configRet = CM_Get_Device_Interface_PropertyW(
+        currentInterface,
+        &DEVPKEY_DeviceInterface_Serial_PortName,
+        &devPropType,
+        NULL,
+        &devPropSize,
+        0);
+    if (configRet != CR_BUFFER_SMALL) {
+        // Handle error
+        ...
+    }
+
+    // Allocate the buffer
+    devPropBuffer = malloc(devPropSize);
+    if (devPropBuffer == NULL) {
+        // Handle error
+        ...
+    }
+
+    configRet = CM_Get_Device_Interface_PropertyW(
+        currentInterface,
+        &DEVPKEY_DeviceInterface_Serial_PortName,
+        &devPropType,
+        devPropBuffer,
+        &devPropSize,
+        0);
+    if (configRet != CR_SUCCESS) {
+        // Handle error
+        ...
+    }
+
+    // Now, check if the interface is the one we are interested in
+    if (wcscmp(devPropBuffer, L"UART0") == 0) {
+        free(devPropBuffer);
+        break;
+    }
+
+    // Advance to the next string (past the terminating NULL)
+    currentInterface += wcslen(currentInterface) + 1;
+    free(devPropBuffer);
+}
+
+//
+// currentInterface now either points to NULL (there was no match and we iterated
+// over all interfaces without a match) - or, it points to the interface with
+// the friendly name UART0, in which case we can open it.
+//
+if (currentInterface == NULL) {
+    // Handle interface not found error
+    ...
+}
+
+//
+// Now open the device interface as we would a COMx style serial port.
+//
+HANDLE portHandle = CreateFileW(
+                        currentInterface,
+                        GENERIC_READ | GENERIC_WRITE,
+                        0,
+                        NULL,
+                        OPEN_EXISTING,
+                        0,
+                        NULL);
+if (portHandle == INVALID_HANDLE_VALUE) {
+    // Handle error
+    ...
+}
+
+free(deviceInterfaceListBuffer);
+deviceInterfaceListBuffer = NULL;
+currentInterface = NULL;
+
+//
+// We are now able to send IO requests to the device.
+//
+... = ReadFile(portHandle, ..., ..., ..., NULL);
+```
+
+Note that an application may also [subscribe for notifications of device interface arrival and device removal](../install/registering-for-notification-of-device-interface-arrival-and-device-removal) in order to open or close a handle to the controller/port when the device becomes available or unavailable.

--- a/windows-driver-docs-pr/serports/device-interface-publication-sercx.md
+++ b/windows-driver-docs-pr/serports/device-interface-publication-sercx.md
@@ -40,7 +40,7 @@ Example device definition (excluding vendor specific information necessary to de
 The specified UUID (`daffd814-6eba-4d8c-8a91-bc9bbf4aa301`) **must** be used, and the entry `SerCx-FriendlyName` must be defined for SerCx/SerCx2 to create the device interface.
 
 ### Registry Key
-For development purposes, the `SerCxFriendlyName` may also be configured as a property in the device's hardware key in the registry. The `CM_Open_DevNode_Key` method may be used to access the device's [hardware key](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/opening-a-device-s-hardware-key) and add the property `SerCxFriendlyName` to the device, which is used by SerCx/SerCx2 to retrieve the friendly name for the device interface.
+For development purposes, the `SerCxFriendlyName` may also be configured as a property in the device's hardware key in the registry. The `CM_Open_DevNode_Key` method may be used to access the device's [hardware key](/windows-hardware/drivers/install/opening-a-device-s-hardware-key) and add the property `SerCxFriendlyName` to the device, which is used by SerCx/SerCx2 to retrieve the friendly name for the device interface.
 
 It is not recommended to set this key via an extension INF - it is provided primarily for testing and development purposes. The recommended approach is to enable the feature via ACPI as documented above.
 

--- a/windows-driver-docs-pr/serports/toc.yml
+++ b/windows-driver-docs-pr/serports/toc.yml
@@ -38,6 +38,8 @@
     items: 
     - name: "Accessing a Device on a SerCx2-Managed Serial Port"
       href: accessing-a-device-on-a-sercx2-managed-serial-port.md
+    - name: "Device Interface publication for a SerCx or SerCx2 managed Serial Port"
+      href: device-interface-publication-sercx.md
     - name: "Peripheral Drivers for Devices on SerCx2-Managed Serial Ports"
       href: peripheral-drivers-for-devices-on-sercx2-managed-serial-ports.md
     - name: "Opening a SerCx2-Managed Serial Port"


### PR DESCRIPTION
This change adds documentation for a SerCx/SerCx2 feature that allows for device interface publication from the Cx.

Also updates ToC, and modernizes overview page from a HTML table to markdown.