### PR TITLE
Add documentation for File System Filter verification

### DIFF
--- a/windows-driver-docs-pr/devtest/file-system-filter-verification.md
+++ b/windows-driver-docs-pr/devtest/file-system-filter-verification.md
@@ -1,3 +1,13 @@
+---
+title: File System Filter Verification
+description: Details on the Filter Verifier
+keywords:
+- File System Filter Verification feature WDK Driver Verifier
+- Minifilter verification WDK Driver Verifier
+- Filter Verifier WDK Driver Verifier
+ms.date: 03/17/2023
+---
+
 # File System Filter Verification
 
 ### Usage Validation

--- a/windows-driver-docs-pr/devtest/file-system-filter-verification.md
+++ b/windows-driver-docs-pr/devtest/file-system-filter-verification.md
@@ -64,19 +64,19 @@ To proceed, type one of four one-letter commands:
 
 You can activate the File System Filter Verification feature for one or more drivers by using the `verifier.exe` command line. For details, see [Selecting Driver Verifier Options](selecting-driver-verifier-options.md).
 
-The recommended way to start Filter Verifier is with the **/standard** option of `verifier.exe`, since it provides additional useful features such as special pool and pool tracking:
+The recommended way to start Filter Verifier is with the **/standard** option of `verifier.exe`, since it provides additional useful features such as [special pool](special-pool.md) and [pool tracking](pool-tracking.md):
 ```
 verifier.exe /standard /driver MyFilter.sys
 ```
 Verification starts when the minifilter driver registers with the filter anager.
-- **Enabling Only Filter Verifier in Windows 11 and Later Versions of indows**
+- **Enabling Only Filter Verifier in Windows 11 and Later Versions of Windows**
     To enable the minimal set of Filter Verifier checks, enable the [I/O Verification](../devtest/i-o-verification.md) and [File System Filter Verification](../devtest/file-system-filter-verification.md) options in Driver Verifier (*verifier.exe*). For example:
 
     ```
     verifier.exe /ruleclasses 5 37 /driver MyFilter.sys
     ```
 
-- **Enabling Only Filter Verifier in Windows 10 and Prior Versions of indows**
+- **Enabling Only Filter Verifier in Windows 10 and Prior Versions of Windows**
     To enable the minimal set of Filter Verifier checks, specify the minifilter driver's name and enable the [I/O Verification](../devtest/i-o-verification.md) option in Driver Verifier (*verifier.exe*). For example:
 
     ```

--- a/windows-driver-docs-pr/devtest/file-system-filter-verification.md
+++ b/windows-driver-docs-pr/devtest/file-system-filter-verification.md
@@ -1,0 +1,84 @@
+# File System Filter Verification
+
+### Usage Validation
+Filter Verifier validates the following usage in a minifilter driver:
+
+* Correct use of parameters and calling context
+* Correct return values from preoperation and postoperation callback routines
+* Consistent and coherent changes to parameters in callback data
+
+### Filter Manager Object Tracking
+Filter Verifier tracks the following filter manager objects:
+
+* Filter Contexts (stream contexts, file contexts, etc.)
+* Callback Data structures
+* Queued Work Items
+* NameInformation structures
+* File Objects
+* Filter Objects
+* Instance Objects
+* Volume Objects
+
+For reference-counted structures, such as filter contexts and name information structures, Filter Verifier will break into the debugger upon unloading the filter driver if any reference counts appear to have been leaked. It will print instructions on how you can use the [!fltkd debugger extension](/windows-hardware/drivers/ifs/development-and-testing-tools#fltkd-debugger-extension) to find the leaked structures.
+
+### Filter Verifier Violations
+When Filter Verifier detects a violation, it prints a message in the debugger describing the violation. For most violations it also halts execution and prompts the user to take some action. For example:
+```
+FILTER VERIFIER ERROR: A filter returned an unknown pre-operation callback status.
+(Filter = FFFFAC04A21CD8A0 (MyFilter), Status = 0xbaadf00d)
+Break, ignore, zap or remove ?
+```
+To proceed, type one of four one-letter commands:
+* `B` or `b` for **Break**: This breaks into the debugger where you may perform further investigation.
+* `I` or `i` for **Ignore**: Resumes execution. If this violation is encountered again, Filter Verifier will print the violation message to the debugger, halt execution, and display the prompt.
+* `Z` or `z` for **Zap**: Resumes execution. If this violation is encountered again, Filter Verifier will print the violation message to the debugger, but will NOT halt execution.
+* `R` or `r` for **Remove**: Resumes execution. If this violation is encountered again, Filter Verifier will NOT print the violation message and will NOT halt execution.
+
+> [!NOTE]
+> When using Filter Verifier on a driver that has been built with complier optimizations enabled, you may occasionally encounter a Filter Verifier error consistently claiming that your filter leaked references to one or more resources even when you cannot find a cause for a leak in your code. The message will begin with text similar to the following:
+> ```
+>FILTER VERIFIER ERROR: A filter (Filter = FFFFAC04A21CD8A0 (MyFilter)) leaked references to the following resources:
+> ```
+> You may also see a message indicating that object tracking is out of sync, such as:
+> ```
+> FILTER VERIFIER WARNING: Filter manager verifier object tracking may be out of sync for the system
+> ```
+> The most common cause of this condition is that Filter Verifier was unable to identify the true caller of a Filter Manager API due to a tail call optimization. This may occur when a routine in your driver calls a Filter Manager API as its last line. For example:
+> ```c
+> void MyWorkItemCallback(PFLT_GENERIC_WORKITEM WorkItem,
+>                         PVOID Filter,
+>                         PVOID Context)
+>{
+>    // Do some stuff
+>    ...
+>    FltFreeGenericWorkItem(WorkItem);
+>}
+> ```
+> There are a couple of ways to verify that this has happened:
+> 1. Disable optimization of the suspect routine by wrapping it in `#pragma optimize("", off) ... #pragma optimize("", on)`.
+> 2. Reorder your code such that the Filter Manager API call is not the last thing happening in your routine.
+>
+> If the error no longer reproduces after trying one of those options, it is likely a false positive.
+
+### Activating This Option
+
+You can activate the File System Filter Verification feature for one or more drivers by using the `verifier.exe` command line. For details, see [Selecting Driver Verifier Options](selecting-driver-verifier-options.md).
+
+The recommended way to start Filter Verifier is with the **/standard** option of `verifier.exe`, since it provides additional useful features such as special pool and pool tracking:
+```
+verifier.exe /standard /driver MyFilter.sys
+```
+Verification starts when the minifilter driver registers with the filter anager.
+- **Enabling Only Filter Verifier in Windows 11 and Later Versions of indows**
+    To enable the minimal set of Filter Verifier checks, enable the [I/O Verification](../devtest/i-o-verification.md) and [File System Filter Verification](../devtest/file-system-filter-verification.md) options in Driver Verifier (*verifier.exe*). For example:
+
+    ```
+    verifier.exe /ruleclasses 5 37 /driver MyFilter.sys
+    ```
+
+- **Enabling Only Filter Verifier in Windows 10 and Prior Versions of indows**
+    To enable the minimal set of Filter Verifier checks, specify the minifilter driver's name and enable the [I/O Verification](../devtest/i-o-verification.md) option in Driver Verifier (*verifier.exe*). For example:
+
+    ```
+    verifier.exe /flags 0x10 /driver MyFilter.sys
+    ```

--- a/windows-driver-docs-pr/devtest/file-system-filter-verification.md
+++ b/windows-driver-docs-pr/devtest/file-system-filter-verification.md
@@ -10,14 +10,16 @@ ms.date: 03/17/2023
 
 # File System Filter Verification
 
-### Usage Validation
+## Usage Validation
+
 Filter Verifier validates the following usage in a minifilter driver:
 
 * Correct use of parameters and calling context
 * Correct return values from preoperation and postoperation callback routines
 * Consistent and coherent changes to parameters in callback data
 
-### Filter Manager Object Tracking
+## Filter Manager Object Tracking
+
 Filter Verifier tracks the following filter manager objects:
 
 * Filter Contexts (stream contexts, file contexts, etc.)
@@ -31,13 +33,16 @@ Filter Verifier tracks the following filter manager objects:
 
 For reference-counted structures, such as filter contexts and name information structures, Filter Verifier will break into the debugger upon unloading the filter driver if any reference counts appear to have been leaked. It will print instructions on how you can use the [!fltkd debugger extension](/windows-hardware/drivers/ifs/development-and-testing-tools#fltkd-debugger-extension) to find the leaked structures.
 
-### Filter Verifier Violations
+## Filter Verifier Violations
+
 When Filter Verifier detects a violation, it prints a message in the debugger describing the violation. For most violations it also halts execution and prompts the user to take some action. For example:
+
 ```
 FILTER VERIFIER ERROR: A filter returned an unknown pre-operation callback status.
 (Filter = FFFFAC04A21CD8A0 (MyFilter), Status = 0xbaadf00d)
 Break, ignore, zap or remove ?
 ```
+
 To proceed, type one of four one-letter commands:
 * `B` or `b` for **Break**: This breaks into the debugger where you may perform further investigation.
 * `I` or `i` for **Ignore**: Resumes execution. If this violation is encountered again, Filter Verifier will print the violation message to the debugger, halt execution, and display the prompt.
@@ -45,15 +50,20 @@ To proceed, type one of four one-letter commands:
 * `R` or `r` for **Remove**: Resumes execution. If this violation is encountered again, Filter Verifier will NOT print the violation message and will NOT halt execution.
 
 > [!NOTE]
-> When using Filter Verifier on a driver that has been built with complier optimizations enabled, you may occasionally encounter a Filter Verifier error consistently claiming that your filter leaked references to one or more resources even when you cannot find a cause for a leak in your code. The message will begin with text similar to the following:
+> When using Filter Verifier on a driver that has been built with compiler optimizations enabled, you may occasionally encounter a Filter Verifier error consistently claiming that your filter leaked references to one or more resources even when you cannot find a cause for a leak in your code. The message will begin with text similar to the following:
+>
 > ```
 >FILTER VERIFIER ERROR: A filter (Filter = FFFFAC04A21CD8A0 (MyFilter)) leaked references to the following resources:
 > ```
+>
 > You may also see a message indicating that object tracking is out of sync, such as:
+>
 > ```
 > FILTER VERIFIER WARNING: Filter manager verifier object tracking may be out of sync for the system
 > ```
+>
 > The most common cause of this condition is that Filter Verifier was unable to identify the true caller of a Filter Manager API due to a tail call optimization. This may occur when a routine in your driver calls a Filter Manager API as its last line. For example:
+>
 > ```c
 > void MyWorkItemCallback(PFLT_GENERIC_WORKITEM WorkItem,
 >                         PVOID Filter,
@@ -64,21 +74,25 @@ To proceed, type one of four one-letter commands:
 >    FltFreeGenericWorkItem(WorkItem);
 >}
 > ```
+>
 > There are a couple of ways to verify that this has happened:
 > 1. Disable optimization of the suspect routine by wrapping it in `#pragma optimize("", off) ... #pragma optimize("", on)`.
 > 2. Reorder your code such that the Filter Manager API call is not the last thing happening in your routine.
 >
 > If the error no longer reproduces after trying one of those options, it is likely a false positive.
 
-### Activating This Option
+## Activating This Option
 
 You can activate the File System Filter Verification feature for one or more drivers by using the `verifier.exe` command line. For details, see [Selecting Driver Verifier Options](selecting-driver-verifier-options.md).
 
 The recommended way to start Filter Verifier is with the **/standard** option of `verifier.exe`, since it provides additional useful features such as [special pool](special-pool.md) and [pool tracking](pool-tracking.md):
+
 ```
 verifier.exe /standard /driver MyFilter.sys
 ```
-Verification starts when the minifilter driver registers with the filter anager.
+
+Verification starts when the minifilter driver registers with the filter manager.
+
 - **Enabling Only Filter Verifier in Windows 11 and Later Versions of Windows**
     To enable the minimal set of Filter Verifier checks, enable the [I/O Verification](../devtest/i-o-verification.md) and [File System Filter Verification](../devtest/file-system-filter-verification.md) options in Driver Verifier (*verifier.exe*). For example:
 

--- a/windows-driver-docs-pr/devtest/toc.yml
+++ b/windows-driver-docs-pr/devtest/toc.yml
@@ -640,6 +640,8 @@
       href: code-integrity-checking.md
     - name: "WDF verification"
       href: wdf-verification.md
+    - name: "File System Filter verification"
+      href: file-system-filter-verification.md
     - name: "Driver Verifier: What's new"
       href: driver-verifier--what-s-new.md
     - name: "Using Driver Verifier"

--- a/windows-driver-docs-pr/devtest/using-volatile-settings.md
+++ b/windows-driver-docs-pr/devtest/using-volatile-settings.md
@@ -19,7 +19,7 @@ However, you can activate and deactivate some options without rebooting. These a
 This section explains the volatile settings and how to use them on the versions of Driver Verifier included in different versions of Windows.
 
 > [!NOTE]
-> This option will be deprecated in a future release of Windows. A replacement option for Windows 11 is provided with the **/now** [Verifier Command](verifier-command-line.md).
+> This option will be deprecated in a future release of Windows. A replacement for Windows 11 is provided with the **/dif [<ruleclass_1> <ruleclass_2> ...] /now** option. See [Verifier Command Line](verifier-command-line.md).
 
 ### Changing Options Without Rebooting
 
@@ -34,7 +34,7 @@ As of Windows 11, only the following flags can be used with volatile:
 ```
 
 > [!NOTE]
-> A number of other flags in Windows 11 may be enabled without reboot using the **/now** command. The supported flags are described in [Verifier Command](verifier-command-line.md).
+> A number of other flags in Windows 11 may be enabled without reboot using the **/dif [<ruleclass_1> <ruleclass_2> ...] /now** command. The supported flags are described in [Verifier Command Line](verifier-command-line.md).
 
 As of Windows 10, only the following flags can be used with volatile:
 

--- a/windows-driver-docs-pr/devtest/verifier-command-line.md
+++ b/windows-driver-docs-pr/devtest/verifier-command-line.md
@@ -23,7 +23,12 @@ You can type several options on the same single line. For example:
 verifier /flags 7 /driver beep.sys disksdd.sys
 ```
 
-**Windows 11**
+**Windows 11 Syntax**
+
+You can use the **/volatile** parameter with some Driver Verifier **/flags** options. For details, see [Using Volatile Settings](using-volatile-settings.md).
+
+> [!NOTE]
+> The **/volatile** parameter will be deprecated in a future version of Windows. In Windows 11 the replacement option is the **/dif** *DifEnabledRule* **/now** option. See the section *Windows 11 Rule Classes* below for the rule classes that can be enabled using this option.
 
 ```
   verifier /standard /all
@@ -53,50 +58,8 @@ verifier /flags 7 /driver beep.sys disksdd.sys
   verifier /help
 ```
 
-Starting in Windows 11, these driver interception framework (DIF) enabled options can be enabled using the /dif option.
 
-The **/dif** command automatically includes rule class 36, DIF mode, but **/ruleclasses** and **/rc** do not. Flags marked with (!) in the help text require DIF mode to be enabled. All Standard rule classes can be enabled without also enabling DIF mode.
-
-Rules marked with (^) in the help text can be enabled without reboot using the **/dif [<ruleclass_1> <ruleclass_2> <ruleclass_k>] /now** command.
-
-**Standard Rule Classes**
-
- Value | Rule | /now
-|------|------|-----|
-1 | Special pool | yes
-2 | Force IRQL checking | no
-4 | Pool tracking | yes
-5 | I/O verification | yes
-6 | Deadlock detection | no
-8 | DMA checking | no
-9 | Security checks | yes
-12 | Miscellaneous checks | yes
-18 | DDI compliance checking | yes
-34 | WDF verification | no
-
-
-**Additional Rule Classes**
-
- Value | Rule | /now | Needs DIF Mode?
-|------|------|------|-------|
-3 | Randomized low resources simulation | no | no
-10 | Force pending I/O requests | no | no
-11 | IRP logging | no | no
-14 | Invariant MDL checking for stack | no | no
-15 | Invariant MDL checking for driver | no | no
-16 | Power framework delay fuzzing | no | no
-17 | Port/miniport interface checking | no | no
-19 | Systematic low resources simulation | yes | yes
-20 | DDI compliance checking (additional) | yes | no
-22 | NDIS/WIFI verification | no | no
-24 | Kernel synchronization delay fuzzing | no | no
-25 | VM switch verification | no | no
-26 | Code integrity checks | no | no
-33 | Driver isolation checks | no | yes
-35 | DDI checking (additional IRQL rules) | yes | yes
-36 | DIF mode | yes | n/a
-
-**Windows 10**
+**Windows 10 Syntax**
 
 You can use the **/volatile** parameter with some Driver Verifier **/flags** options and with **/standard**. You cannot use **/volatile** with the **/flags** options for [DDI compliance checking](ddi-compliance-checking.md), [Power Framework Delay Fuzzing](concurrency-stress-test.md) or [Storport Verification](dv-storport-verification.md). For details, see [Using Volatile Settings](using-volatile-settings.md).
 
@@ -125,7 +88,7 @@ You can use the **/volatile** parameter with some Driver Verifier **/flags** opt
   verifier /help
 ```
 
-**Windows 8.1**
+**Windows 8.1 Syntax**
 
 You can use the **/volatile** parameter with some Driver Verifier **/flags** options and with **/standard**. You cannot use **/volatile** with the **/flags** options for [DDI compliance checking](ddi-compliance-checking.md), [Power Framework Delay Fuzzing](concurrency-stress-test.md), [Storport Verification](dv-storport-verification.md). For details, see [Using Volatile Settings](using-volatile-settings.md).
 
@@ -213,10 +176,10 @@ Controls whether the settings for Driver Verifier are enabled after a reboot. To
 </table>
 
 **/dif** *DifEnabledRule*
-Enable checking using a Dif enabled rule. Checking will take effect the next time the system is rebooted. Added in Windows 11.
+Enable checking using a DIF enabled rule. Checking will take effect the next time the system is rebooted. Added in Windows 11.
 
-**/dif /now** *DifEnabledRule*
-Immediately enable checking using a Dif enabled rule. Enables the rule classes immediately without needing reboot. This option
+**/dif** *DifEnabledRule* **/now**
+Immediately enable checking using a DIF enabled rule. Enables the rule classes immediately without needing reboot. This option
 is only valid if no rule classes are already running. See the Windows 11 rule class descriptions for the rule classes capable of immediate activation.
 
 **/driver** *DriverList*
@@ -542,7 +505,7 @@ Any combination of the following values is permitted.
 
 The ruleclasses parameter is available starting with Windows Version 1803.
 
-The ruleclasses parameter encompasses a larger set of verification classes than the '/flags' parameter above. While '/flags' is limited to a 32 bit bitmap expression, this option can include more than 32 verification classes. Each positive decimal integer represents a verification class. Multiple classes can be expressed by separating each class id with a space character. The following rule classes IDs are available.
+The ruleclasses parameter encompasses a larger set of verification classes than the **/flags** parameter above. While **/flags** is limited to a 32 bit bitmap expression, this option can include more than 32 verification classes. Each positive decimal integer represents a verification class. Multiple classes can be expressed by separating each class id with a space character. The following rule classes IDs are available.
 
 **Standard Rule Classes**
 
@@ -558,10 +521,11 @@ The ruleclasses parameter encompasses a larger set of verification classes than 
 12 | Miscellaneous checks
 18 | DDI compliance checking
 34 | WDF Verification
+37 | File System Filter verification (5)
 
 **Additional Rule Classes**
 
-These rule classes are intended for specific scenario testing. Rule classes are marked with `(*)` require I/O Verification (5) that will be automatically enabled. Flags marked with `(**)` support disabling of individual rules. Flags marked with `(***)` are in logging mode by default and require /onecheck in order to crash upon violation.
+These rule classes are intended for specific scenario testing. Rule classes marked with `(*)` require I/O Verification (5) and automatically enable it. Rule classes marked with `(**)` support disabling of individual rules. Rule classes marked with `(***)` are in logging mode by default and require **/onecheck** in order to crash upon violation.
 
 Flags marked with `(!)` require DIF mode (rule class 36) to be enabled.
 
@@ -586,50 +550,55 @@ Flags marked with `(!)` require DIF mode (rule class 36) to be enabled.
 
 ### Windows 11 Rule Classes
 
-Starting with Windows 11 the following rule classes are available.
+Starting with Windows 11 the following standard rule classes are available. These rule classes are all enabled when using the **/standard** option.
+
+The **/now** column indicates which rule classes can be enabled without a reboot using the **/dif** *DifEnabledRule* **/now** option.
 
 
 **Standard Rule Classes**
 
- Value | Rule
-|------|------|
-1 | Special pool (^)
-2 | Force IRQL checking (^)
-4 | Pool tracking (^)
-5 | I/O verification (^)
-6 | Deadlock detection
-8 | DMA checking
-9 | Security checks (^)
-12 | Miscellaneous checks (^)
-18 | DDI compliance checking (^)
-34 | WDF Verification
+ Value | Rule | /now
+|------|------|------|
+1 | Special pool | yes
+2 | Force IRQL checking | yes
+4 | Pool tracking | yes
+5 | I/O verification | yes
+6 | Deadlock detection | no
+8 | DMA checking | no
+9 | Security checks  | yes
+12 | Miscellaneous checks | yes
+18 | DDI compliance checking | yes
+34 | WDF Verification | no
+37 | File System Filter verification | no
 
-The '/dif' command automatically includes rule class 36, DIF mode, but
-/ruleclasses and /rc do not. Flags marked with (!) require DIF mode to
-be enabled. Flags marked with (^) can be enabled without reboot using
-the '/dif [<ruleclass_1> <ruleclass_2> <ruleclass_k>] /now' command.
+Note that rule class 37 (File System Filter verification) requires that rule class 5 (I/O verification) also be enabled. Please see [File System Filter verification](file-system-filter-verification.md) for more information about this rule class.
 
 **Additional Rule Classes**
 
-Flags marked with `(!)` require DIF mode (rule class 36) to be enabled.
+The following additional rule classes are available. 
 
- Value | Rule
-|------|------|
-3 | Randomized low resources simulation
-10 | Force pending I/O requests (*)
-11 | IRP logging (*)
-14 | Invariant MDL checking for stack (*)
-15 | Invariant MDL checking for driver (*)
-16 | Power framework delay fuzzing
-17 | Port/miniport interface checking
-19 | Systematic low resources simulation (!, ^)
-20 | DDI compliance checking - additional (^)
-22 | NDIS/WIFI verification (**)
-24 | Kernel synchronization delay fuzzing
-25 | VM switch verification
-26 | Code integrity checks
-33 | Driver isolation checks (***, !)
-36 | DIF mode
+* The **/now** column indicates which rule classes can be enabled without a reboot using the **/dif** *DifEnabledRule* **/now** option.
+* The **Rule classes required** column indicates which rule classes must also be enabled to use the given rule class. Note that the **/dif** command automatically includes rule class 36 (DIF mode) but **/ruleclasses** and **/rc** do not.
+* Rule classes marked with `(**)` support disabling of individual rules.
+* Rule classes marked with `(***)` are in logging mode by default and require the **/onecheck** option to crash upon violation.
+
+ Value | Rule | /now | Rule classes required
+|------|------|------|------|
+3 | Randomized low resources simulation | no | none
+10 | Force pending I/O requests | no | 5
+11 | IRP logging | no | 5
+14 | Invariant MDL checking for stack | no | 5
+15 | Invariant MDL checking for driver | no | 5
+16 | Power framework delay fuzzing | no | none
+17 | Port/miniport interface checking | no | none
+19 | Systematic low resources simulation | yes | 36
+20 | DDI compliance checking - additional | yes | none
+22 | NDIS/WIFI verification `(**)` | no | none
+24 | Kernel synchronization delay fuzzing | no | none
+25 | VM switch verification | no | none
+26 | Code integrity checks | no | none
+33 | Driver isolation checks `(***)` | no | 36
+36 | DIF mode | yes | none
 
 
 **/log** *LogFileName* \[**/interval**|*Seconds*\]

--- a/windows-driver-docs-pr/ifs/development-and-testing-tools.md
+++ b/windows-driver-docs-pr/ifs/development-and-testing-tools.md
@@ -41,25 +41,6 @@ In WinDbg, type **!fltkd.help** for a full list of commands.
 
 ## Filter Verifier
 
-Filter Verifier is an [I/O Verification](../devtest/i-o-verification.md) option in [Driver Verifier](../devtest/driver-verifier.md) that validates minifilter driver usage of filter manager functions. Filter Verifier is installed with the filter manager. Developers should always develop minifilter drivers with Driver Verifier and Filter Verifier enabled.
+Filter Verifier is an option in [Driver Verifier](../devtest/driver-verifier.md) that validates minifilter driver usage of filter manager functions. Filter Verifier is installed with the filter manager. Developers are strongly recommended to always develop minifilter drivers with Filter Verifier enabled.
 
-To use Filter Verifier, specify the minifilter driver's name and enable the I/O Verification option in Driver Verifier (*Verifier.exe*). Verification starts when the minifilter driver registers with the filter manager.
-
-Filter Verifier validates the following usage in a minifilter driver:
-
-* Correct use of parameters and calling context
-* Correct return values from preoperation and postoperation callback routines
-* Consistent and coherent changes to parameters in callback data
-
-Filter Verifier tracks the following filter manager objects:
-
-* Contexts
-* Callback Data structures
-* Queued Work Items
-* NameInformation structures
-* File Objects
-* Filter Objects
-* Instance Objects
-* Volume Objects
-
-In a command prompt, type ```verifier /?``` to see syntax and a full list of parameters.
+For information on how to enable Filter Verifier and what it validates, please see [File System Filter Verification](../devtest/file-system-filter-verification.md).


### PR DESCRIPTION
Filter Verifier is light on documentation. This PR:
* Moves the existing Filter Verifier description to its own page and expands it.
* Adds documentation to the main Driver Verifier page showing how to enable Filter Verifier and linking to its description page.
* Streamlines the Driver Verifier command-line syntax page a bit to remove redundant mentions of rule classes.