### PR TITLE
update doc and sample for Update a shipping label

### DIFF
--- a/windows-driver-docs-pr/dashboard/update-a-shipping-label.md
+++ b/windows-driver-docs-pr/dashboard/update-a-shipping-label.md
@@ -21,7 +21,7 @@ This method has the following syntax. The other sections in this topic provide u
 |:--|:--|
 | PATCH | `https://manage.devcenter.microsoft.com/v2.0/my/hardware/products/{productID}/submissions/{submissionId}/shippingLabels/{shippingLabelId}` |
 
-The *productID*, *submissionID* and *shippingLabelId* in the method represent the product, submission and shipping label to be updated.
+The *productID*, *submissionID* and *shippingLabelID* in the method represent the product, submission and shipping label to be updated.
 
 ### Request header
 
@@ -32,11 +32,11 @@ The *productID*, *submissionID* and *shippingLabelId* in the method represent th
 
 ### Request parameters
 
-Do not provide request parameters for this method. 
+Do not provide request parameters for this method.
 
 ### Request body
 
-The following example demonstrates the JSON request body a shipping label. Only the following types of changes can be made to a shipping label:
+The following example demonstrates the JSON request body for a shipping label. Only the following types of changes can be made to a shipping label:
 
 * Add hardware IDs
 * Remove/expire hardware IDs
@@ -48,15 +48,15 @@ The following example demonstrates the JSON request body a shipping label. Only 
 
 ```json
 {
-  "targetingInfo": {
+  "targeting": {
     "chids": [
       {
-        "chid": "812fac65-9c26-473c-b3a9-1eb3803ac22c",
-        "action": "add"
+        "action": "add",
+        "chid": "812fac65-9c26-473c-b3a9-1eb3803ac22c"
       },
       {
-        "chid": "aed6336d-0958-444c-89b6-bf471191d6f0",
-        "action": "remove"
+        "action": "remove",
+        "chid": "aed6336d-0958-444c-89b6-bf471191d6f0"
       }
     ],
     "hardwareIds": [
@@ -78,7 +78,7 @@ The following example demonstrates the JSON request body a shipping label. Only 
     "restrictedToAudiences": [
       "00000000-0000-0000-0000-000000000000",
       "00000000-0000-0000-0000-000000000001"
-      ],
+    ],
     "inServicePublishInfo": {
       "flooring": "RS1",
       "ceiling": "RS3"
@@ -98,11 +98,11 @@ Points to note:
 
 * To learn how to get a list of audiences for your organization, see [get audience](get-audience-data.md).
 
-* The hardware ID object should contain a valid combination of bundle ID, PNP ID, OS Code, and INF name when creating a new shipping label. To get the valid, allowed combinations of these attributes for your submission (package), download the driver metadata file (provided as a link) when you get the details of a submission. For details, see [Driver package metadata](driver-package-metadata.md).
+* The hardware ID object should contain a valid combination of bundle ID, PNP ID, OS Code, and INF name when updating a shipping label. To get the valid, allowed combinations of these attributes for your submission (package), download the driver metadata file (provided as a link) when you get the details of a submission. For details, see [Driver package metadata](driver-package-metadata.md).
 
 ### Request examples
 
-The following example demonstrates how to update a product.
+The following example demonstrates how to update a shipping label.
 
 ```json
 PATCH https://manage.devcenter.microsoft.com/v2.0/my/hardware/products/14461751976964156/submissions/1152921504621467600/shippingLabels/1152921504606980300 HTTP/1.1


### PR DESCRIPTION
Update and correct properties and verbiage throughout the document.
- replace `"targetingInfo":` with `"targeting":` in the request body sample to provide clarity and reduce future issues.
- replace `shippingLabelId` with `shippingLabelID` to match document
- reorder `chids` object properties to match document
- replace `product` with `shipping label`
- replace `new` with `updating`

References to issues which warrant this change:
- https://github.com/MicrosoftDocs/windows-driver-docs/issues/3296
- https://github.com/MicrosoftDocs/windows-driver-docs/issues/1438