### PR TITLE
Add minimum OS version for all flags

### DIFF
--- a/windows-driver-docs-pr/devtest/pnputil-command-syntax.md
+++ b/windows-driver-docs-pr/devtest/pnputil-command-syntax.md
@@ -39,7 +39,7 @@ Adds driver package(s) into the driver store. Command available starting in Wind
 PNPUTIL /add-driver <filename.inf | *.inf> [/subdirs] [/install] [/reboot]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 1607:
 
 - `/subdirs` - traverse sub directories for driver packages
 - `/install` - install/update drivers on any matching devices
@@ -53,7 +53,7 @@ Deletes a driver package from the driver store. Command available starting in Wi
 PNPUTIL /delete-driver <oem#.inf> [/uninstall] [/force] [/reboot]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 1607:
 
 - `/uninstall` - uninstall driver package from any devices using it
 - `/force` - delete driver package even when it is in use by devices
@@ -94,7 +94,7 @@ PNPUTIL /disable-device [<instance ID> | /deviceid <device ID>]
                         [/reboot] [/force]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 2004:
 
 - `/reboot` - reboot system if needed to complete the operation
 
@@ -118,7 +118,7 @@ PNPUTIL /enable-device [<instance ID> | /deviceid <device ID>]
                        [/reboot]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 2004:
 
 - `/reboot` - reboot system if needed to complete the operation
 
@@ -141,7 +141,7 @@ PNPUTIL /restart-device [<instance ID> | /deviceid <device ID>]
                         [/reboot]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 2004:
 
 - `/reboot` - reboot system if needed to complete the operation
 
@@ -164,7 +164,7 @@ PNPUTIL /remove-device [<instance ID> | /deviceid <device ID>]
                        [/subtree] [/reboot] [/force]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 2004:
 
 - `/subtree` - remove entire device subtree, including any child devices
 - `/reboot` - reboot system if needed to complete the operation
@@ -187,7 +187,7 @@ Scans the system for any device hardware changes. Command available starting in 
 /scan-devices [/instanceid <instance ID>] [/async]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 2004:
 
 - `/instanceid <instance ID>` - scan device subtree for changes
 - `/async` - scan for changes asynchronously
@@ -205,7 +205,7 @@ PNPUTIL /enum-devices [/connected | /disconnected]
                       [/properties] [/resources]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 1903:
 
 - `/connected` - filter by connected devices
 - `/disconnected` - filter by disconnected devices
@@ -213,6 +213,9 @@ Flags:
 - `/class <name | GUID>` - filter by device class name or GUID
 - `/problem [<code>]` - filter by devices with problems or filter by specific problem code
 - `/relations` - display parent and child device relations
+
+Flags available starting in Windows 10, version 2004:
+
 - `/drivers` - display matching and installed drivers
 
 Flags available starting in Windows 11 version 21H2:
@@ -237,7 +240,7 @@ Enumerates all device interfaces on the system. Command available starting in Wi
 PNPUTIL /enum-interfaces [/enabled | /disabled] [/class <GUID>] [/properties]
 ```
 
-Flags:
+Flags available starting in Windows 10, version 1903:
 
 - `/enabled` - filter by enabled interfaces
 - `/disabled` - filter by disabled interfaces
@@ -255,7 +258,7 @@ Enumerates all device classes on the system. Command available starting in Windo
 PNPUTIL /enum-classes [/class <name | GUID>] [/services]
 ```
 
-Flags:
+Flags available starting in Windows 11, version 22H2:
 
 - `/class <name | GUID>` - filter by device class name or GUID
 - `/services` - display device class services


### PR DESCRIPTION
Backfill minimum OS versions for all pnputil flags. Flags introduced in Win 11 21H1 or later have minimum versions documented, but pre-Win 11 flags had no specified minimum version.