### PR TITLE
Fix incorrect PnPUtil path

### DIFF
--- a/windows-driver-docs-pr/usbcon/tutorial--write-your-first-usb-client-driver--kmdf-.md
+++ b/windows-driver-docs-pr/usbcon/tutorial--write-your-first-usb-client-driver--kmdf-.md
@@ -176,7 +176,7 @@ You can also manually install the driver on the target computer by using Device 
 
 - [PnPUtil](../devtest/pnputil.md)
 
-    This tool comes with the Windows. It is in Windows\\System31. You can use this utility to add the driver to the driver store.
+    This tool comes with the Windows. It is in Windows\\System32. You can use this utility to add the driver to the driver store.
 
     ```cmd
     C:\>pnputil /a m:\MyDriver_.inf


### PR DESCRIPTION
PnPUtil.exe is installed to `Windows\System32` and not `Windows\System31`.

Evidence:
```
C:\>where pnputil
C:\Windows\System32\pnputil.exe
```