### PR TITLE
Fix incorrect grammar and unnecessary word in 0x13 bugcheck description

### DIFF
--- a/windows-driver-docs-pr/debugger/bug-check-0x13--empty-thread-reaper-list.md
+++ b/windows-driver-docs-pr/debugger/bug-check-0x13--empty-thread-reaper-list.md
@@ -1,6 +1,6 @@
 ---
 title: Bug Check 0x13 EMPTY_THREAD_REAPER_LIST
-description: The EMPTY_THREAD_REAPER_LIST bug check has a value of 0x00000013.This bug check appears is not currently used by Windows.
+description: The EMPTY_THREAD_REAPER_LIST bug check has a value of 0x00000013. This bug check is not currently used by Windows.
 keywords: ["Bug Check 0x13 EMPTY_THREAD_REAPER_LIST", "EMPTY_THREAD_REAPER_LIST"]
 ms.date: 11/06/2023
 topic_type:


### PR DESCRIPTION
This adds a space between a period and the next sentence and also removes the erroneous word "appears"