### PR TITLE
Fix swapped MP2 and MP3 GUIDs

### DIFF
--- a/windows-driver-docs-pr/audio/subformat-guids-for-compressed-audio-formats.md
+++ b/windows-driver-docs-pr/audio/subformat-guids-for-compressed-audio-formats.md
@@ -58,13 +58,13 @@ The GUIDs for the available compressed audio formats are listed in the following
 </tr>
 <tr class="odd">
 <td align="left"><p>0x04</p></td>
-<td align="left"><p>00000004-0cea-0010-8000-00aa00389b71</p>
+<td align="left"><p>00000005-0cea-0010-8000-00aa00389b71</p>
 <p>KSDATAFORMAT_SUBTYPE_IEC61937_MPEG3</p></td>
 <td align="left"><p>MPEG-3 (Layer 3)</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>0x05</p></td>
-<td align="left"><p>00000005-0cea-0010-8000-00aa00389b71</p>
+<td align="left"><p>00000004-0cea-0010-8000-00aa00389b71</p>
 <p>KSDATAFORMAT_SUBTYPE_IEC61937_MPEG2</p></td>
 <td align="left"><p>MPEG-2 (Multichanel)</p></td>
 </tr>


### PR DESCRIPTION
While CEA-861 defines MP2 as 0x5 and MP3 as 0x4, the GUIDs defined in ksmedia.h are in reverse order.

Update documentation to the correct GUIDs as defined in ksmedia.h.

Based on Windows SDK 10.0.22621.