### PR TITLE
Fix WDK installation instructions with missing components

### DIFF
--- a/windows-driver-docs-pr/download-the-wdk.md
+++ b/windows-driver-docs-pr/download-the-wdk.md
@@ -36,7 +36,11 @@ When you install Visual Studio 2022, select the **Desktop development with C++**
 
 * MSVC v143 - VS 2022 C++ ARM64/ARM64EC Spectre-mitigated libs (Latest)</br>
 * MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (Latest)</br>
-Hint: Use the Search box to look for "msvc 64 latest" or "msvc 64 latest spectre" to quickly see these components.</br>
+* C++ ATL for latest v143 build tools with Spectre Mitigations (ARM64/ARM64EC)</br>
+* C++ ATL for latest v143 build tools with Spectre Mitigations (x86 & x64)</br>
+* C++ MFC for latest v143 build tools with Spectre Mitigations (ARM64/ARM64EC)</br>
+* C++ MFC for latest v143 build tools with Spectre Mitigations (x86 & x64)</br>
+Hint: Use the Search box to look for "64 latest spectre" to quickly see these components.</br>
 
  Don't worry about the SDK at this point; you install this next in step 2 below.
 

--- a/windows-driver-docs-pr/install-the-wdk-using-winget.md
+++ b/windows-driver-docs-pr/install-the-wdk-using-winget.md
@@ -33,7 +33,7 @@ You can use WinGet to install Visual Studio 2022 with all the workloads and comp
   "components": [
     "Microsoft.Component.MSBuild",
     "Microsoft.VisualStudio.Component.CoreEditor",
-    "Microsoft.VisualStudio.Component.NuGet.BuildTools",
+    "Microsoft.VisualStudio.Component.NuGet",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.TextTemplating",
     "Microsoft.VisualStudio.Component.VC.ASAN",
@@ -45,7 +45,7 @@ You can use WinGet to install Visual Studio 2022 with all the workloads and comp
     "Microsoft.VisualStudio.Component.VC.ATLMFC",
     "Microsoft.VisualStudio.Component.VC.CoreIde",
     "Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre",
-    "Microsoft.VisualStudio.Component.VC.MFC.ARM64"
+    "Microsoft.VisualStudio.Component.VC.MFC.ARM64",
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
     "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64EC.Spectre",
@@ -56,7 +56,7 @@ You can use WinGet to install Visual Studio 2022 with all the workloads and comp
     "Microsoft.VisualStudio.Component.Windows10SDK",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Workload.NativeDesktop"
   ]
 }
 ```


### PR DESCRIPTION
* Add missing ATL and MFC dependencies on instructions to install the WDK.
* Fix VS .vsconfig file on Installation via Winget instructions.