### PR TITLE
Update porting-ndis-miniport-drivers-to-netadaptercx.md

### DIFF
--- a/windows-driver-docs-pr/netcx/porting-ndis-miniport-drivers-to-netadaptercx.md
+++ b/windows-driver-docs-pr/netcx/porting-ndis-miniport-drivers-to-netadaptercx.md
@@ -161,5 +161,4 @@ The [!ndiskd.netadapter](../debuggercmds/-ndiskd-netadapter.md) debugger extensi
 
 Using the steps in this topic, you should have a working driver that starts and stops your device.
 
-> [!NOTE]
-> NetAdapterCx currently does not support iSCSI boot.
+**Note**: NetAdapterCx doesn't currently support iSCSI boot.

--- a/windows-driver-docs-pr/netcx/porting-ndis-miniport-drivers-to-netadaptercx.md
+++ b/windows-driver-docs-pr/netcx/porting-ndis-miniport-drivers-to-netadaptercx.md
@@ -160,3 +160,6 @@ The [!ndiskd.netadapter](../debuggercmds/-ndiskd-netadapter.md) debugger extensi
 ## Conclusion
 
 Using the steps in this topic, you should have a working driver that starts and stops your device.
+
+> [!NOTE]
+> NetAdapterCx currently does not support iSCSI boot.


### PR DESCRIPTION
Add a note mentioning iSCSI boot is not supported in Netadaptercx