### PR TITLE
Chnage 'Status Block' to 'Return Value'

### DIFF
--- a/windows-driver-docs-pr/ifs/fsctl-set-external-backing.md
+++ b/windows-driver-docs-pr/ifs/fsctl-set-external-backing.md
@@ -38,7 +38,7 @@ To perform this operation, call [**FltFsControlFile**](/windows-hardware/drivers
 
 - **OutputBufferLength** [in]: Set to 0.
 
-## Status block
+## Return Value
 
 [**FltFsControlFile**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltfscontrolfile) or [**ZwFsControlFile**](/previous-versions/ff566462(v=vs.85)) returns STATUS_SUCCESS if the operation succeeds. Otherwise, the appropriate NTSTATUS values is returned.
 


### PR DESCRIPTION
The text jarred when I read it because I thought there was an `IO_STATUS_BLOCK` involved...