### PR TITLE
Update mbr2gpt-tool-test-guidance.md

### DIFF
--- a/windows-driver-docs-pr/bringup/mbr2gpt-tool-test-guidance.md
+++ b/windows-driver-docs-pr/bringup/mbr2gpt-tool-test-guidance.md
@@ -94,9 +94,9 @@ Restore data and settings using USMT Load State.
 
 1. Detach VHD
 
-1. Create a generation 2 VM with UEFI support and attach the above VHD created from Step 5 above.
+1. Create a Generation 2 VM with UEFI support and attach the above VHD created from Step 5 above.
 
-1. Boot to Windows 10, version 1703 in UEFI mode using a gen 2 VM.
+1. Boot to Windows 10, version 1703 in UEFI mode using a Generation 2 VM.
 
 For any of the scenarios above, you can convert an MBR disk with BitLocker-encrypted volumes as long as protection has been suspended. To resume BitLocker after conversion, you will need to delete the existing protectors and recreate them.
 


### PR DESCRIPTION
Improve readability and branding compliance by spelling out "Generation 2" explicitly instead of using acronyms where applicable.