### PR TITLE
Correct error path pool free pointer in sample

### DIFF
--- a/windows-driver-docs-pr/kernel/writing-a-bug-check-callback-routine.md
+++ b/windows-driver-docs-pr/kernel/writing-a-bug-check-callback-routine.md
@@ -251,8 +251,9 @@ SetupTriageDataCallback(VOID)
                                                 (PUCHAR)"Example"); 
 
     if ( !bSuccess ) {
-         ExFreePoolWithTag(gTriageDumpDataArray, 'Xmpl');
-         gTriageDumpDataArray = NULL;
+        ExFreePoolWithTag(pBuffer, 'Xmpl');
+        gTriageDumpDataArray = NULL;
+        gBugcheckTriageCallbackRecord = NULL;
          return STATUS_UNSUCCESSFUL;
     }
 


### PR DESCRIPTION
gTriageDumpDataArray points into the middle of a pool allocation that starts at pBuffer (and gBugcheckTriageCallbackRecord).