### PR TITLE
Remove "/ac" from the signtool command

### DIFF
--- a/windows-driver-docs-pr/dashboard/code-signing-attestation.md
+++ b/windows-driver-docs-pr/dashboard/code-signing-attestation.md
@@ -124,7 +124,7 @@ To create the CAB file:
 1. Use the process recommended by the EV certificate provider to sign the CAB file with your EV certificate. For example, to sign your CAB file with a SHA256 Certificate/Digest Algorithm/Timestamp, enter the following command: 
 
    ```cmd
-   C:\Echo> SignTool sign /ac "C:\MyEVCert.cer" /s MY /n "Company Name" /fd sha256 /tr http://sha256timestamp.ws.symantec.com/sha256/timestamp /td sha256 /v "C:\Echo\Disk1\Echo.cab"
+   C:\Echo> SignTool sign /s MY /n "Company Name" /fd sha256 /tr http://sha256timestamp.ws.symantec.com/sha256/timestamp /td sha256 /v "C:\Echo\Disk1\Echo.cab"
    ```
 
    > [!IMPORTANT]


### PR DESCRIPTION
The "/ac" and its accompanying argument is a remnant from the "old days" before EV Certs.  EV Certs can't be stored in a local path anymore (they're on a token or other hardware device)... so /ac doesn't apply anymore.  The command works perfectly with /ac <path> removed (we've done this, multiple times).