### PR TITLE
Update how-setup-ranks-drivers--windows-vista-and-later-.md

### DIFF
--- a/windows-driver-docs-pr/install/how-setup-ranks-drivers--windows-vista-and-later-.md
+++ b/windows-driver-docs-pr/install/how-setup-ranks-drivers--windows-vista-and-later-.md
@@ -21,7 +21,7 @@ The rank of a driver package is a composite value that depends on a driver packa
 
 A rank is represented by a value of type DWORD. A rank is the sum of a signature score, a feature score, and an identifier score. A rank is formatted as 0x*SSGGTHHH*, where *S*, *G*, *T*, and *H* are four-bitfields and the *SS*, *GG*, and *THHH* fields represent the three ranking scores, as follows:
 
--   The [signature score](signature-score--windows-vista-and-later-.md) ranks a driver package based on whether its digital signature is trusted. The signature score depends only on the value of the *SS* field. An unspecified signature score is represented as 0x*SS*0000000.
+-   The [signature score](signature-score--windows-vista-and-later-.md) ranks a driver package based on whether its digital signature is trusted. The signature score depends only on the value of the *SS* field. An unspecified signature score is represented as 0x*SS*000000.
 
     For an overview on how Windows Vista and later versions of Windows use a driver package's signature to determine how the driver package is installed, see [Signature Categories and Driver Installation](signature-categories-and-driver-installation.md).
 


### PR DESCRIPTION
I found error.
0x*SS*0000000 is not correct I think
I think 0x*SS*000000 is correct.
Now I removed extra zero, please review this.

Best regards,
Brian Hernandez