### PR TITLE
Describe the /f parameter of .restart

### DIFF
--- a/windows-driver-docs-pr/debuggercmds/-restart--restart-target-application-.md
+++ b/windows-driver-docs-pr/debuggercmds/-restart--restart-target-application-.md
@@ -19,8 +19,13 @@ The **.restart** command restarts the target application.
 Do not confuse this command with the [**.restart (Restart Kernel Connection)**](-restart--restart-kernel-connection-.md) command, which works only in kernel mode.
 
 ```dbgcmd
-.restart 
+.restart [/f]
 ```
+
+## Parameters
+
+**/f** 
+Forces the restart of a process which wasn't launched by the debugger (e.g. a process which was attached to). This will use the command line of the PEB to restart the process. However, this may not be 100% identical to how the process was started and then attached to.
 
 ## Environment
 
@@ -38,7 +43,14 @@ For more information about how to issue this command and an overview of related 
 
 CDB and WinDbg can restart a target application if the debugger originally created the application. You can use the **.restart** command even if the target application has already closed.
 
-However, if the application is running and the debugger is later attached to the process, the **.restart** command has no effect.
+However, if the application is running and the debugger is later attached to the process, the **.restart** command displays the following message and has no other effect:
+```dbgcmd
+0:000> .restart
+Process attaches cannot be restarted.  If you want to
+restart the process, use !peb to get what command line
+to use and other initialization information.
+```
+Use the **/f** option to mimic a restart.
 
 After the process is restarted, it immediately breaks into the debugger.
 


### PR DESCRIPTION
.restart has a /f parameter which restarts a process that was attached to. This was not documented.