### PR TITLE
Add new per-device DMA remapping opt-in mechanism information

### DIFF
--- a/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
+++ b/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
@@ -1,10 +1,10 @@
 ---
-title: Enabling DMA Remapping for Device Drivers
+title: Enable DMA Remapping for Device Drivers
 description: Enable and opt-into Direct Memory Access(DMA) remapping to ensure compatibility with Kernel DMA Protection and DMAGuard policies.
 ms.date: 01/21/2025
 ---
 
-# Enabling DMA remapping for device drivers
+# Enable DMA remapping for device drivers
 
 To ensure compatibility with [Kernel DMA Protection](/windows/security/information-protection/kernel-dma-protection-for-thunderbolt) and [DMAGuard Policy](/windows/client-management/mdm/policy-csp-dmaguard#dmaguard-deviceenumerationpolicy), PCIe device drivers can opt into Direct Memory Access (DMA) remapping.
 
@@ -24,7 +24,7 @@ Drivers perform DMA using the following interfaces:
 
 To adjust the DMA remapping policy for your driver, add an INF directive. There are two methods to this: a per-device (strongly recommended and preferred) mechanism and a per-driver (legacy) mechanism.
 
-## Per-device Opt-In Mechanism
+## Per-device opt-in mechanism
 
 For Windows 24H2 and above, please use this per-device method. Note that this per-device opt-in will completely override the legacy per-driver method, if present (i.e. **DmaRemappingCompatible** key is ignored if **RemappingSupported** is set).
 
@@ -64,7 +64,7 @@ Valid values for **DMA Management\RemappingFlags** are:
 
 These registry keys will appear under the enumeration tree: ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\PCI\<device instance path>\Device Parameters\DMA Management``
 
-### Per-driver Opt-In Mechanism
+### Per-driver opt-in mechanism
 
 Only use this per-driver method for Windows versions up to Windows 11 23H2. It is strongly recommended to use the [per-device method as outlined above](#per-device-opt-in-mechanism).
 
@@ -92,7 +92,7 @@ The registry key will appear under the service installation tree: ``HKEY_LOCAL_M
 > [!WARNING]
 > DMA remapping is not supported for graphics device drivers.
 
-## Validating that DMA remapping is enabled for a specific device driver instance
+## Validate that DMA remapping is enabled for a specific device driver instance
 
 Use the latest Windows build with VT-d/AMD-Vi enabled to test driver functionality on Intel x64 and AMD64 systems.
 

--- a/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
+++ b/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
@@ -92,7 +92,7 @@ The registry key will appear under the service installation tree: ``HKEY_LOCAL_M
 > [!WARNING]
 > DMA remapping is not supported for graphics device drivers.
 
-## Validate that DMA remapping is enabled for a specific device driver instance
+## Validating that DMA remapping is enabled for a specific device driver instance
 
 Use the latest Windows build with VT-d/AMD-Vi enabled to test driver functionality on Intel x64 and AMD64 systems.
 

--- a/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
+++ b/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
@@ -22,7 +22,53 @@ Drivers perform DMA using the following interfaces:
 
 - [NDIS interfaces](/windows-hardware/drivers/ddi/_netvista/)
 
-To adjust the DMA remapping policy for your driver, add an INF directive such as the following to the service installation section:
+To adjust the DMA remapping policy for your driver, add an INF directive. There are two methods to this: a per-device (strongly recommended and preferred) mechanism and a per-driver (legacy) mechanism.
+
+## Per-device Opt-In Mechanism
+
+For Windows 24H2 and above, please use this per-device method. Note that this per-device opt-in will completely override the legacy per-driver method, if present (i.e. **DmaRemappingCompatible** key is ignored if **RemappingSupported** is set).
+
+Add an INF directive such as the following to the device enumeration section:
+
+``` inf
+ [MyDriver_Device.NT.HW]
+ AddReg=DMA_Remapping_OptIn_AddReg
+ 
+ [DMA_Remapping_OptIn_AddReg]
+ HKR,"DMA Management","RemappingSupported",0x00010001,1
+```
+
+Valid values for **DMA Management\RemappingSupported** are:
+
+| Value | Meaning |
+| ----- | ------- |
+| 0     | Opt out. This indicates to the system that the device and driver are incompatible with DMA remapping. |
+| 1     | Opt in. This indicates to the system that the device and driver is fully compatible with DMA remapping. |
+| No registry key | Let the system determine the policy. |
+
+<div>
+Optionally, you add RemappingFlags to further control the behavior:
+
+``` inf
+ [DMA_Remapping_OptIn_AddReg]
+ HKR,"DMA Management","RemappingSupported",0x00010001,1
+ HKR,"DMA Management","RemappingFlags",0x00010001,0x00000001
+```
+
+Valid values for **DMA Management\RemappingFlags** are:
+
+| Value | Meaning |
+| ----- | ------- |
+| 0     | If **RemappingSupported** is 1, opt in unconditionally. |
+| 1     | If **RemappingSupported** is 1, opt in but only when one or more of the following conditions are met: A. If the device is an external device (eg. Thunderbolt); B. If DMA verification is enabled in Driver Verifier. |
+| No registry key | Same as 0 value. |
+
+These registry keys will appear under the enumeration tree: ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\PCI\<device instance path>\Device Parameters\DMA Management``
+
+### Per-driver Opt-In Mechanism
+Only use this per-driver method for Windows versions up to Windows 11 23H2. It is strongly recommended to use the [per-device method as outlined above](#Per-device-Opt-In-Mechanism).
+
+Add an INF directive such as the following to the service installation section:
 
 ```inf
   [MyServiceInstall_AddReg]
@@ -36,18 +82,19 @@ Valid values for **DmaRemappingCompatible** are:
 | 0     | Opt out. This indicates to the system that your driver is incompatible with DMA remapping. |
 | 1     | Opt in. This indicates to the system that your driver is fully compatible with DMA remapping. |
 | 2     | Opt in, but only when one or more of the following conditions are met: A. If the device is an external device (eg. Thunderbolt); B. If DMA verification is enabled in Driver Verifier. |
+| 3     | Opt in
 | No registry key | Let the system determine the policy. |
 
 When testing your driver, enable Driver Verifier. For testing purposes under Driver Verifier, the value of the INF directive for opting in external devices is promoted to 1.
 
-Use the latest Windows 10 build with VT-d/AMD-Vi enabled to test driver functionality on Intel x64 and AMD64 systems.
+The registry key will appear under the service installation tree: ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\<driver name>\Parameters``.
 
 > [!WARNING]
 > DMA remapping is not supported for graphics device drivers.
->
-> Support for version 3 is only available on Windows 11.  On Windows 10, if you specify 3 in the INF, the system falls back to a value of 2.
 
 ## Validating that DMA remapping is enabled for a specific device driver instance
+
+Use the latest Windows build with VT-d/AMD-Vi enabled to test driver functionality on Intel x64 and AMD64 systems.
 
 To check if a specific driver has opted into DMA remapping, look in Device Manager, in the device's **Details** tab, for the values corresponding to the DMA remapping policy property. A driver can query the [**DEVPKEY_Device_DmaRemappingPolicy**](../install/devpkey-device-dmaremappingpolicy.md) property to determine the DMA remapping capability of the device. See potential return values on that page, and note that these return values are not the same as the values for **DmaRemappingCompatible** listed in the previous section.
 

--- a/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
+++ b/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
@@ -1,7 +1,7 @@
 ---
-title: Enabling DMA remapping for device drivers
-description: Enable and opt-into Direct Memory Access (DMA) remapping to ensure compatibility with Kernel DMA Protection and DMAGuard policies
-ms.date: 06/21/2024
+title: Enabling DMA Remapping for Device Drivers
+description: Enable and opt-into Direct Memory Access(DMA) remapping to ensure compatibility with Kernel DMA Protection and DMAGuard policies.
+ms.date: 01/21/2025
 ---
 
 # Enabling DMA remapping for device drivers
@@ -30,7 +30,7 @@ For Windows 24H2 and above, please use this per-device method. Note that this pe
 
 Add an INF directive such as the following to the device enumeration section:
 
-``` inf
+```inf
  [MyDriver_Device.NT.HW]
  AddReg=DMA_Remapping_OptIn_AddReg
  
@@ -41,15 +41,14 @@ Add an INF directive such as the following to the device enumeration section:
 Valid values for **DMA Management\RemappingSupported** are:
 
 | Value | Meaning |
-| ----- | ------- |
+|-------|---------|
 | 0     | Opt out. This indicates to the system that the device and driver are incompatible with DMA remapping. |
 | 1     | Opt in. This indicates to the system that the device and driver is fully compatible with DMA remapping. |
 | No registry key | Let the system determine the policy. |
 
-<div>
 Optionally, you add RemappingFlags to further control the behavior:
 
-``` inf
+```inf
  [DMA_Remapping_OptIn_AddReg]
  HKR,"DMA Management","RemappingSupported",0x00010001,1
  HKR,"DMA Management","RemappingFlags",0x00010001,0x00000001
@@ -58,7 +57,7 @@ Optionally, you add RemappingFlags to further control the behavior:
 Valid values for **DMA Management\RemappingFlags** are:
 
 | Value | Meaning |
-| ----- | ------- |
+|-------|---------|
 | 0     | If **RemappingSupported** is 1, opt in unconditionally. |
 | 1     | If **RemappingSupported** is 1, opt in but only when one or more of the following conditions are met: A. If the device is an external device (eg. Thunderbolt); B. If DMA verification is enabled in Driver Verifier. |
 | No registry key | Same as 0 value. |
@@ -66,6 +65,7 @@ Valid values for **DMA Management\RemappingFlags** are:
 These registry keys will appear under the enumeration tree: ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\PCI\<device instance path>\Device Parameters\DMA Management``
 
 ### Per-driver Opt-In Mechanism
+
 Only use this per-driver method for Windows versions up to Windows 11 23H2. It is strongly recommended to use the [per-device method as outlined above](#per-device-opt-in-mechanism).
 
 Add an INF directive such as the following to the service installation section:
@@ -78,7 +78,7 @@ Add an INF directive such as the following to the service installation section:
 Valid values for **DmaRemappingCompatible** are:
 
 | Value | Meaning |
-| ----- | ------- |
+|-------|---------|
 | 0     | Opt out. This indicates to the system that your driver is incompatible with DMA remapping. |
 | 1     | Opt in. This indicates to the system that your driver is fully compatible with DMA remapping. |
 | 2     | Opt in, but only when one or more of the following conditions are met: A. If the device is an external device (eg. Thunderbolt); B. If DMA verification is enabled in Driver Verifier. |

--- a/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
+++ b/windows-driver-docs-pr/pci/enabling-dma-remapping-for-device-drivers.md
@@ -66,7 +66,7 @@ Valid values for **DMA Management\RemappingFlags** are:
 These registry keys will appear under the enumeration tree: ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\PCI\<device instance path>\Device Parameters\DMA Management``
 
 ### Per-driver Opt-In Mechanism
-Only use this per-driver method for Windows versions up to Windows 11 23H2. It is strongly recommended to use the [per-device method as outlined above](#Per-device-Opt-In-Mechanism).
+Only use this per-driver method for Windows versions up to Windows 11 23H2. It is strongly recommended to use the [per-device method as outlined above](#per-device-opt-in-mechanism).
 
 Add an INF directive such as the following to the service installation section:
 


### PR DESCRIPTION
This updates the enabling DMA remapping page with new information on the latest per-device registry opt-in mechanism. Additionally corrected some outdated information on the old per-driver opt-in method.