### PR TITLE
Update WinDbg docs for shortcuts

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -21137,8 +21137,8 @@
         "redirect_document_id":  false
     },
     {
-        "source_path":  "windows-driver-docs-pr/debugger/windbg-keyboard-shortcuts-preview.md",
-        "redirect_URL":  "/windows-hardware/drivers/debuggercmds/windbg-keyboard-shortcuts-preview",
+        "source_path":  "windows-driver-docs-pr/debugger/windbg-keyboard-shortcuts.md",
+        "redirect_URL":  "/windows-hardware/drivers/debuggercmds/windbg-keyboard-shortcuts",
         "redirect_document_id":  false
     },
     {

--- a/windows-driver-docs-pr/debuggercmds/toc.yml
+++ b/windows-driver-docs-pr/debuggercmds/toc.yml
@@ -12,7 +12,7 @@
   - name: "WinDbg – Settings and workspaces"
     href: windbg-setup-preview.md
   - name: "WinDbg – Keyboard shortcuts"
-    href: windbg-keyboard-shortcuts-preview.md
+    href: windbg-keyboard-shortcuts.md
   - name: "WinDbg - Start a user-mode session"
     href: windbg-user-mode-preview.md
   - name: "WinDbg - Start a kernel mode session"

--- a/windows-driver-docs-pr/debuggercmds/windbg-keyboard-shortcuts.md
+++ b/windows-driver-docs-pr/debuggercmds/windbg-keyboard-shortcuts.md
@@ -30,6 +30,18 @@ Ctrl+Shift+F5   |   Restart
 Shift+F5    |   Stop debugging
 Alt+H,D     | Detach
 
+### Command Window
+
+| Keystroke     | Description |
+| ------------- | ------------------------- |
+Ctrl+M          | Toggle focus between output pane (mark mode) and input box
+Ctrl+Space      | Trigger command completion list popup
+TAB             | Trigger next autocompletion
+Shift+TAB       | Trigger previous autocompletion
+Ctrl+F          | Open find box
+Ctrl+[          | Select previous output pane section
+Ctrl+]          | Select next output pane section
+
 ### Setup
 
 | Keystroke     | Description             |
@@ -96,5 +108,5 @@ Ctrl+Alt+V      |       Toggle Verbose Mode
 
 ## See Also
 
-[WinDbg Features](../debugger/debugging-using-windbg-preview.md)
+[WinDbg Features](../debugger/debugging-using-windbg.md)
 

--- a/windows-driver-docs-pr/debuggercmds/windbg-overview.md
+++ b/windows-driver-docs-pr/debuggercmds/windbg-overview.md
@@ -101,7 +101,7 @@ To report any bugs or suggest a new feature, you can follow the feedback button 
 - Review these topics to install and configure WinDbg:
   - [WinDbg – Command line startup options](windbg-command-line-preview.md)
   - [WinDbg – Settings and workspaces](windbg-setup-preview.md)
-  - [WinDbg – Keyboard shortcuts](windbg-keyboard-shortcuts-preview.md)
+  - [WinDbg – Keyboard shortcuts](windbg-keyboard-shortcuts.md)
 
 - These topics describe how to get connected to the environment that you want to debug:
   - [WinDbg – Start a user-mode session](windbg-user-mode-preview.md)


### PR DESCRIPTION
Several new shortcuts for WinDbgX never made it into the docs, as well as some new shortcuts.

This change adds the missing shortcuts.