### PR TITLE
PartialCheckedBuild: Remove dead link

### DIFF
--- a/windows-driver-docs-pr/devtest/boot-parameters-to-load-a-partial-checked-build.md
+++ b/windows-driver-docs-pr/devtest/boot-parameters-to-load-a-partial-checked-build.md
@@ -11,7 +11,7 @@ ms.date: 07/19/2024
 
 # Boot Parameters to Load a Partial Checked Build
 
-A *partial checked build* contains checked build versions of the kernel and HAL and a free build of the remainder of the operating system. For details, see [Installing Just the Checked Operating System and HAL (For Windows Vista and Later)](installing-just-the-checked-operating-system-and-hal--for-windows-vist.md).
+A *partial checked build* contains checked build versions of the kernel and HAL and a free build of the remainder of the operating system.
 
 > [!NOTE]
 > Checked builds were available on older versions of Windows, before Windows 10 version 1803.


### PR DESCRIPTION
Additionally, it seems that the checked kernel and HAL are no longer provided, I couldn't find them in the WDK installation directory, and the documentation about this in the Microsoft docs seems to be lacking. If so, another approach is to completely delete this page (I can amend this if necessary).