### PR TITLE
Update code-signing-reqs.md, remove Entrust

### DIFF
--- a/windows-driver-docs-pr/dashboard/code-signing-reqs.md
+++ b/windows-driver-docs-pr/dashboard/code-signing-reqs.md
@@ -21,7 +21,7 @@ For more extensive information on driver signing requirements see the following 
 Code signing certificates can be purchased from one of the following certificate authorities:
 
 - [DigiCert code signing certificate](https://order.digicert.com/step1/code_signing)
-- [Entrust code signing certificate](https://www.entrust.com/products/digital-signing/code-signing-certificates)
+- [Sectigo code signing certificate](https://www.sectigo.com/ssl-certificates-tls/code-signing)
 - [GlobalSign code signing certificate](https://go.microsoft.com/fwlink/p/?LinkId=620888)
 - [SSL.com code signing certificate](https://www.ssl.com/certificates/ev-code-signing/)
 


### PR DESCRIPTION
Replace the link to Entrust with Sectigo, since Entrust is no longer issuing certificates and refers to Sectigo. See https://store.entrust.com/code-signing-solutions

A point of clarification here though, is this list exhaustive? It is not made clear if these are the *only* valid certificate authorities for EV Certificates, or if you can use any authority in the MS Trusted Root Program, a bit of clarification here would help. Another section of the documentation links to the Trusted Root Program list.