### PR TITLE
Add Help Page for Open Dump Errors

### DIFF
--- a/windows-driver-docs-pr/debugger/could-not-open-dump-file.md
+++ b/windows-driver-docs-pr/debugger/could-not-open-dump-file.md
@@ -1,0 +1,84 @@
+---
+title: Could not open dump file
+description: Could not open dump file
+keywords: ["could not open dump file (error)", "minidump does not have system info", "could not match dump file signature"]
+ms.date: 04/07/2025
+---
+
+# Could Not Open Dump File
+
+This guide provides steps to troubleshoot and resolve common errors encountered when opening a dump file in WinDbg.
+
+## Common Errors and Solutions
+
+### 1. **Could not open dump file**
+
+This error typically occurs when the dump file is corrupt or inaccessible.
+
+#### Steps to Resolve:
+
+- Verify the file path and ensure the dump file exists at the specified location.
+- Check file permissions to ensure you have read access to the dump file.
+- Use the `DumpChk` tool to validate the dump file:
+  ```console
+  dumpchk <path-to-dump-file>
+  ```
+  If the file is corrupt, you may need to regenerate the dump file.
+
+### 2. **Access to path is Denied**
+
+This error occurs when the debugger lacks permissions to access the dump file.
+
+#### Steps to Resolve:
+
+- Run WinDbg as an administrator.
+- Ensure the dump file is not in use by another process.
+
+### 3. **Could not match Dump File signature**
+
+This error indicates that the debugger did not recognize the dumpfile  format. This may be caused by an incomplete dump file, encrypted dump file, unsupported format, or file corruption.
+
+#### Steps to Resolve:
+
+- Ensure the dump file was created correctly. Refer to the documentation for the tool used to generate the dump file (e.g., `.dump` command in WinDbg or ProcDump).
+- If the dump is compressed, try uncompressing it and opening the uncompressed dump file.
+- If the dump is encrypted, decrypt it and open the decrypted dump file.
+- If the dump file is incomplete, recreate it with the appropriate settings.
+- Use the `DumpChk` tool to validate the dump file:
+  ```console
+  dumpchk <path-to-dump-file>
+  ```
+  If the file is corrupt, you may need to regenerate the dump file.
+
+### 4. **Minidump does not have System Info**
+
+This error indicates that the debugger cannot locate the System Info stream in the dump. This may be caused by an incomplete dump file, unsupported format, or file corruption.
+
+#### Steps to Resolve:
+
+- Ensure the dump file was created correctly. Refer to the documentation for the tool used to generate the dump file (e.g., `.dump` command in WinDbg or ProcDump).
+- If the dump file is incomplete, recreate it with the appropriate settings.
+- Use the `DumpChk` tool to validate the dump file:
+  ```console
+  dumpchk <path-to-dump-file>
+  ```
+  If the file is corrupt, you may need to regenerate the dump file.
+
+### 5. **End of Central Directory record could not be found.**
+
+This error indicates that the debugger was unable to open the archive. This may be caused by an incomplete file, unsupported archive format (e.g. `.gz`, `.7z`), or file corruption.
+
+#### Steps to Resolve:
+
+- Ensure the archive was created correctly. Refer to the documentation for the tool used to generate the archive.
+- If download was interrupted or incomplete, try downloading again.
+- Try using an alternative tool to extract the archived contents and open the extracted dump file.
+  If the archive is corrupt, you may need to download the uncompressed dump or regenerate the archive.
+
+## See Also
+
+[DumpChk](dumpchk.md)  
+[Kernel-mode dump files](kernel-mode-dump-files.md)  
+[User-Mode dump files](user-mode-dump-files.md)  
+[Linux crash dumps](linux-crash-dumps.md)  
+[WinDbg Command-Line Options](windbg-command-line-options.md)  

--- a/windows-driver-docs-pr/debugger/toc.yml
+++ b/windows-driver-docs-pr/debugger/toc.yml
@@ -2766,3 +2766,5 @@
       href: stack-unwind-information-not-available.md
     - name: "No Header Information Available"
       href: no-header-information-available.md
+    - name: "Could Not Open Dump File"
+      href: could-not-open-dump-file.md


### PR DESCRIPTION
One of the most frequent negative user feedback we get is on failures to open dump files in WinDbg. The error presented to the user is not always clear on why the dump failed to open and what the user can do about it.

This change adds resolution steps for some common errors when opening dumps.