### PR TITLE
WinDbg: Fix getting started installation legacy

### DIFF
--- a/windows-driver-docs-pr/debugger/getting-started-with-windbg--kernel-mode-.md
+++ b/windows-driver-docs-pr/debugger/getting-started-with-windbg--kernel-mode-.md
@@ -9,10 +9,7 @@ ms.topic: get-started
 
 WinDbg is a kernel-mode and user-mode debugger that's included in Debugging Tools for Windows. This article provides exercises to help you get started using WinDbg as a kernel-mode debugger.
 
-For information about how to get Debugging Tools for Windows, see [Download and install the WinDbg Windows debugger](index.md). After you have installed the debugging tools, locate the installation directories for 64-bit (x64) and 32-bit (x86) versions of the tools. For example:
-
-- **C:\Program Files (x86)\Windows Kits\10\Debuggers\x64**
-- **C:\Program Files (x86)\Windows Kits\10\Debuggers\x86**
+For information about how to get WinDbg, see [Download and install the WinDbg Windows debugger](index.md).
 
 ## Set up a kernel-mode debugging
 

--- a/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
+++ b/windows-driver-docs-pr/debugger/getting-started-with-windbg.md
@@ -9,12 +9,7 @@ ms.topic: get-started
 
 WinDbg is a kernel-mode and user-mode debugger that's included in Debugging Tools for Windows. The following hands-on exercises can help you get started using WinDbg as a user-mode debugger.
 
-For information about how to get Debugging Tools for Windows, see [Download and install the WinDbg Windows debugger](index.md).
-
-After you install the debugging tools, find the installation directories for the 64-bit (x64) and 64-bit ARM versions of the tools. For example:
-
-- **C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64**
-- **C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\arm64**
+For information about how to get WinDbg, see [Download and install the WinDbg Windows debugger](index.md).
 
 ## Open Notepad and attach WinDbg
 


### PR DESCRIPTION
Problem: The getting started guide has some legacy from when the standard way to obtain WinDbg was via the debugging tools.

Solution: Modernize it to refer to the standalone WinDbg