### PR TITLE
WinDbg: Fix legacy on ENTER command documentation

### DIFF
--- a/windows-driver-docs-pr/debuggercmds/enter--repeat-last-command-.md
+++ b/windows-driver-docs-pr/debuggercmds/enter--repeat-last-command-.md
@@ -36,9 +36,7 @@ ENTER
 
 ## Remarks
 
-In CDB and KD, pressing the ENTER key by itself at a command prompt reissues the command that you previously entered.
+Pressing the ENTER key by itself at the debugger command prompt reissues the command that you previously entered.
 
-In WinDbg, the ENTER key can have no effect or you can use it to repeat the previous command. You can set this option in the **Options** dialog box. (To open the **Options** dialog box, click **Options** on the **View** menu or click the **Options** button (:::image type="content" source="images/tbopt.png" alt-text="Screenshot of the Options button.":::
-
-If you set ENTER to repeat the last command, but you want to create white space in the [Debugger Command window](../debugger/debugger-command-window.md), use the [**\* (Comment Line Specifier)**](----comment-line-specifier-.md) token and then press ENTER several times.
+If you want to create white space in the [Debugger Command window](../debugger/debugger-command-window.md), use the [**\* (Comment Line Specifier)**](----comment-line-specifier-.md) token and then press ENTER several times.
 

--- a/windows-driver-docs-pr/debuggercmds/enter--repeat-last-command-.md
+++ b/windows-driver-docs-pr/debuggercmds/enter--repeat-last-command-.md
@@ -32,11 +32,10 @@ ENTER
 |Targets |Live, crash dump      |
 |Platforms|All                  |
 
- 
 
 ## Remarks
 
-Pressing the ENTER key by itself at the debugger command prompt reissues the command that you previously entered.
+In CDB, KD and WinDbg, pressing the ENTER key by itself at the debugger command prompt reissues the command that you previously entered. For more information, see [Using Debugger Commands](using-debugger-commands.md).
 
 If you want to create white space in the [Debugger Command window](../debugger/debugger-command-window.md), use the [**\* (Comment Line Specifier)**](----comment-line-specifier-.md) token and then press ENTER several times.
 


### PR DESCRIPTION
Problem: The ENTER command remarks refer to an option which disables repeating the last command on ENTER, this option indeed exists on the legacy WinDbg, but not on the modern version. The modern one seems to just have this enabled by default, with no option to disable it in the UI.

Solution: Remove the sentence regarding this.

Also, I wasn't sure if by convention documentation referring to legacy/classic WinDbg should remain with a side note that it isn't relevant for the new version or just removed completely from the online docs. I can amend this in case this does need to remain.