### PR TITLE
Update examples-of-receive-segment-coalescing.md

### DIFF
--- a/windows-driver-docs-pr/network/examples-of-receive-segment-coalescing.md
+++ b/windows-driver-docs-pr/network/examples-of-receive-segment-coalescing.md
@@ -113,7 +113,7 @@ None of these segments generates an exception.
 
 -   X’SEQ &gt; X.SEQ
 
--   X’.ACK == X.ACK
+-   X’.ACK &gt; X.ACK
 
 None of these segments generates an exception.
 ### Result


### PR DESCRIPTION
X’.ACK shoud greater than X.ACK to demonstrate Piggybacked ACKs