### PR TITLE
EFI and OROM in same package

### DIFF
--- a/windows-driver-docs-pr/dashboard/file-signing-reqs.md
+++ b/windows-driver-docs-pr/dashboard/file-signing-reqs.md
@@ -3,6 +3,7 @@ title: LSA plugin or UEFI firmware signing requirements
 description: LSA plugin or UEFI firmware signing requirements
 ms.topic: article
 ms.date: 04/19/2022
+ms.service: partner-dashboard
 ---
 
 # LSA plugin or UEFI firmware signing requirements
@@ -14,7 +15,7 @@ You can use the Partner Center hardware dashboard to digitally sign [Local Secur
 - LSA plugins and UEFI firmware signing requires an [extended validation (EV) code signing certificate](code-signing-reqs.md#ev-certificate-signed-drivers).
 - All LSA and UEFI submissions must be a single, signed CAB library file, and contain all files required for signing.
 - This file should contain no folders and only the binaries or .efi files to be signed.
-- Do not include option ROMs and EFI applications in the same submission for signing. 
+- Don't include option ROMs and EFI applications in the same submission for signing. 
 - **UEFI FIRMWARE ONLY** - The CAB file signature must match the [Authenticode certificate](../install/authenticode.md) for your organization.
 - Depending on your certificate provider, you may need to use [SignTool](/windows/desktop/SecCrypto/signtool) or an external process.
 - EFI ByteCode (EBC) files must be compiled using the /ALIGN:32 flag for processing to succeed.

--- a/windows-driver-docs-pr/dashboard/file-signing-reqs.md
+++ b/windows-driver-docs-pr/dashboard/file-signing-reqs.md
@@ -14,6 +14,7 @@ You can use the Partner Center hardware dashboard to digitally sign [Local Secur
 - LSA plugins and UEFI firmware signing requires an [extended validation (EV) code signing certificate](code-signing-reqs.md#ev-certificate-signed-drivers).
 - All LSA and UEFI submissions must be a single, signed CAB library file, and contain all files required for signing.
 - This file should contain no folders and only the binaries or .efi files to be signed.
+- Do not include option ROMs and EFI applications in the same submission for signing. 
 - **UEFI FIRMWARE ONLY** - The CAB file signature must match the [Authenticode certificate](../install/authenticode.md) for your organization.
 - Depending on your certificate provider, you may need to use [SignTool](/windows/desktop/SecCrypto/signtool) or an external process.
 - EFI ByteCode (EBC) files must be compiled using the /ALIGN:32 flag for processing to succeed.


### PR DESCRIPTION
Partners should not submit Option ROM and EFI applications in the same package, as they will be signed with different CAs starting October 2025.